### PR TITLE
Add Secret Manager permissions to service account setup

### DIFF
--- a/scripts/service-account-setup.sh
+++ b/scripts/service-account-setup.sh
@@ -180,6 +180,8 @@ echo "Applying IAM roles for $REGISTRATION_TYPE registration..."
 PROJECT_ROLES=(
     "roles/config.agent"
     "roles/iam.workloadIdentityPoolAdmin"
+    "roles/secretmanager.secretAccessor"
+    "roles/secretmanager.viewer"
 )
 
 # Add project-specific roles for project registration


### PR DESCRIPTION
 Add minimal required Secret Manager permissions to the service account setup script:
  - roles/secretmanager.secretAccessor - Read secret values
  - roles/secretmanager.viewer - Get secret metadata and version info
