### PR TITLE
Fix labels limit validation in examples

### DIFF
--- a/examples/generic-registration/variables.tf
+++ b/examples/generic-registration/variables.tf
@@ -184,8 +184,8 @@ variable "labels" {
   }
 
   validation {
-    condition     = length(var.labels) <= 60
-    error_message = "Maximum of 60 custom labels allowed (system labels will be added automatically)."
+    condition     = length(var.labels) <= 64
+    error_message = "Maximum of 64 custom labels allowed."
   }
 }
 

--- a/examples/infrastructure-manager/variables.tf
+++ b/examples/infrastructure-manager/variables.tf
@@ -185,8 +185,8 @@ variable "labels" {
   }
 
   validation {
-    condition     = length(var.labels) <= 60
-    error_message = "Maximum of 60 custom labels allowed (system labels will be added automatically)."
+    condition     = length(var.labels) <= 64
+    error_message = "Maximum of 64 custom labels allowed."
   }
 }
 

--- a/examples/native-terraform/variables.tf
+++ b/examples/native-terraform/variables.tf
@@ -178,8 +178,8 @@ variable "labels" {
   }
 
   validation {
-    condition     = length(var.labels) <= 60
-    error_message = "Maximum of 60 custom labels allowed (system labels will be added automatically)."
+    condition     = length(var.labels) <= 64
+    error_message = "Maximum of 64 custom labels allowed."
   }
 }
 


### PR DESCRIPTION
Fix labels validation limit inconsistency between main module and examples
Update maximum labels from 60 to 64 across all example configurations to align with main module validation rules.