### PR TITLE
fix: handle Pub/Sub permissions when infra project is outside folder scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22"
     }
   }
 }
@@ -101,7 +101,7 @@ module "crowdstrike_gcp_registration" {
 | Name | Version |
 |------|---------|
 | <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | >= 0.0.55 |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.22 |
 ## Resources
 
 | Name | Type |

--- a/docs/.usage.tf
+++ b/docs/.usage.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22"
     }
   }
 }

--- a/examples/generic-registration/README.md
+++ b/examples/generic-registration/README.md
@@ -5,7 +5,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.50 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.22 |
 
 ## Providers
 

--- a/examples/generic-registration/versions.tf
+++ b/examples/generic-registration/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22"
     }
     crowdstrike = {
       source  = "crowdstrike/crowdstrike"

--- a/examples/infrastructure-manager/README.md
+++ b/examples/infrastructure-manager/README.md
@@ -5,7 +5,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.50 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.22 |
 
 ## Providers
 

--- a/examples/infrastructure-manager/versions.tf
+++ b/examples/infrastructure-manager/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22"
     }
     crowdstrike = {
       source  = "crowdstrike/crowdstrike"

--- a/examples/native-terraform/README.md
+++ b/examples/native-terraform/README.md
@@ -5,7 +5,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.50 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.22 |
 
 ## Providers
 

--- a/examples/native-terraform/versions.tf
+++ b/examples/native-terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22"
     }
     crowdstrike = {
       source  = "crowdstrike/crowdstrike"

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,16 @@ module "asset-inventory" {
   depends_on = [module.workload-identity]
 }
 
+# Check if infrastructure project is within registration scope for log ingestion permissions
+module "scope-checker" {
+  count  = var.enable_realtime_visibility ? 1 : 0
+  source = "./modules/scope-checker/"
+
+  registration_type = var.registration_type
+  folder_ids        = var.folder_ids
+  infra_project_id  = var.infra_project_id
+}
+
 module "log-ingestion" {
   count  = var.enable_realtime_visibility ? 1 : 0
   source = "./modules/log-ingestion/"
@@ -79,6 +89,9 @@ module "log-ingestion" {
   resource_prefix   = local.effective_prefix
   resource_suffix   = local.effective_suffix
   labels            = var.labels
+
+  # Scope-based conditional permissions
+  infra_project_in_scope = module.scope-checker[0].infra_project_in_scope
 
   # Optional settings - structured configuration, child module handles defaults
   message_retention_duration       = var.log_ingestion_settings.message_retention_duration
@@ -98,7 +111,7 @@ module "log-ingestion" {
     [for pattern in var.excluded_project_patterns : "resource.labels.project_id=~\"^${replace(replace(pattern, "*", ".*"), "?", ".")}$\""]
   )
 
-  depends_on = [module.workload-identity]
+  depends_on = [module.workload-identity, module.scope-checker]
 }
 
 # CrowdStrike registration settings

--- a/modules/log-ingestion/README.md
+++ b/modules/log-ingestion/README.md
@@ -85,6 +85,7 @@ module "log_ingestion" {
 | [google_logging_organization_sink.crowdstrike_logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_organization_sink) | resource |
 | [google_logging_project_sink.crowdstrike_logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
 | [google_project_iam_member.crowdstrike_monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.crowdstrike_pubsub_project_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.log_ingestion_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_pubsub_schema.crowdstrike_logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_schema) | resource |
 | [google_pubsub_subscription.crowdstrike_logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
@@ -108,6 +109,7 @@ module "log_ingestion" {
 | <a name="input_existing_topic_name"></a> [existing\_topic\_name](#input\_existing\_topic\_name) | Name of existing Pub/Sub topic to use. If empty, creates new topic | `string` | `null` | no |
 | <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folders being registered | `list(string)` | `[]` | no |
 | <a name="input_infra_project_id"></a> [infra\_project\_id](#input\_infra\_project\_id) | Project ID used for CrowdStrike infrastructure resources (topic, subscription, and other components). Defaults to WIF project if not specified | `string` | `null` | no |
+| <a name="input_infra_project_in_scope"></a> [infra\_project\_in\_scope](#input\_infra\_project\_in\_scope) | Whether the infrastructure project is within the registration scope (used for conditional IAM permissions) | `bool` | `true` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Map of labels to be applied to all resources created by this module | `map(string)` | `{}` | no |
 | <a name="input_message_retention_duration"></a> [message\_retention\_duration](#input\_message\_retention\_duration) | Message retention duration for Pub/Sub subscription (e.g., '604800s' for 7 days) | `string` | `"604800s"` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The Google Cloud organization being registered | `string` | `null` | no |

--- a/modules/log-ingestion/main.tf
+++ b/modules/log-ingestion/main.tf
@@ -1,24 +1,6 @@
-# Data source to check if infra_project_id is within folder registration scope
-data "google_project_ancestry" "infra_project" {
-  count   = var.registration_type == "folder" ? 1 : 0
-  project = var.infra_project_id
-}
-
 locals {
   folder_list  = var.folder_ids
   project_list = var.project_ids
-
-  # Extract folder IDs from infra project's ancestors
-  infra_project_folder_ancestors = var.registration_type == "folder" ? [
-    for ancestor in data.google_project_ancestry.infra_project[0].ancestors :
-    ancestor.id if ancestor.type == "folder"
-  ] : []
-
-  # Check if any target folder is an ancestor of infra_project_id
-  infra_project_in_scope = var.registration_type == "folder" ? length(setintersection(
-    toset(var.folder_ids),
-    toset(local.infra_project_folder_ancestors)
-  )) > 0 : true
 
   # Generate resource names with prefix/suffix or use existing names
   topic_name        = var.existing_topic_name != null ? var.existing_topic_name : "${var.resource_prefix}CrowdStrikeLogTopic-${var.registration_id}${var.resource_suffix}"
@@ -236,7 +218,7 @@ resource "google_pubsub_subscription_iam_member" "crowdstrike_subscriber" {
 }
 
 resource "google_pubsub_topic_iam_member" "crowdstrike_viewer" {
-  count = local.infra_project_in_scope ? 1 : 0
+  count = var.infra_project_in_scope ? 1 : 0
 
   topic   = local.create_topic ? google_pubsub_topic.crowdstrike_logs[0].name : data.google_pubsub_topic.existing_crowdstrike_logs[0].name
   project = var.infra_project_id
@@ -247,8 +229,8 @@ resource "google_pubsub_topic_iam_member" "crowdstrike_viewer" {
 }
 
 # Grant CrowdStrike principal project-level Pub/Sub viewer access when infra project is outside registration scope
-resource "google_project_iam_member" "crowdstrike_pubsub_topic_reader" {
-  count = local.infra_project_in_scope ? 0 : 1
+resource "google_project_iam_member" "crowdstrike_pubsub_project_viewer" {
+  count = var.infra_project_in_scope ? 0 : 1
 
   project = var.infra_project_id
   role    = "roles/pubsub.viewer"

--- a/modules/log-ingestion/main.tf
+++ b/modules/log-ingestion/main.tf
@@ -1,6 +1,24 @@
+# Data source to check if infra_project_id is within folder registration scope
+data "google_project_ancestry" "infra_project" {
+  count   = var.registration_type == "folder" ? 1 : 0
+  project = var.infra_project_id
+}
+
 locals {
   folder_list  = var.folder_ids
   project_list = var.project_ids
+
+  # Extract folder IDs from infra project's ancestors
+  infra_project_folder_ancestors = var.registration_type == "folder" ? [
+    for ancestor in data.google_project_ancestry.infra_project[0].ancestors :
+    ancestor.id if ancestor.type == "folder"
+  ] : []
+
+  # Check if any target folder is an ancestor of infra_project_id
+  infra_project_in_scope = var.registration_type == "folder" ? length(setintersection(
+    toset(var.folder_ids),
+    toset(local.infra_project_folder_ancestors)
+  )) > 0 : true
 
   # Generate resource names with prefix/suffix or use existing names
   topic_name        = var.existing_topic_name != null ? var.existing_topic_name : "${var.resource_prefix}CrowdStrikeLogTopic-${var.registration_id}${var.resource_suffix}"
@@ -218,7 +236,20 @@ resource "google_pubsub_subscription_iam_member" "crowdstrike_subscriber" {
 }
 
 resource "google_pubsub_topic_iam_member" "crowdstrike_viewer" {
+  count = local.infra_project_in_scope ? 1 : 0
+
   topic   = local.create_topic ? google_pubsub_topic.crowdstrike_logs[0].name : data.google_pubsub_topic.existing_crowdstrike_logs[0].name
+  project = var.infra_project_id
+  role    = "roles/pubsub.viewer"
+  member  = var.wif_iam_principal
+
+  depends_on = [google_pubsub_topic.crowdstrike_logs, data.google_pubsub_topic.existing_crowdstrike_logs]
+}
+
+# Grant CrowdStrike principal project-level Pub/Sub viewer access when infra project is outside registration scope
+resource "google_project_iam_member" "crowdstrike_pubsub_topic_reader" {
+  count = local.infra_project_in_scope ? 0 : 1
+
   project = var.infra_project_id
   role    = "roles/pubsub.viewer"
   member  = var.wif_iam_principal

--- a/modules/log-ingestion/main.tf
+++ b/modules/log-ingestion/main.tf
@@ -217,6 +217,11 @@ resource "google_pubsub_subscription_iam_member" "crowdstrike_subscriber" {
   depends_on = [google_pubsub_subscription.crowdstrike_logs, data.google_pubsub_subscription.existing_crowdstrike_logs]
 }
 
+moved {
+  from = google_pubsub_topic_iam_member.crowdstrike_viewer
+  to   = google_pubsub_topic_iam_member.crowdstrike_viewer[0]
+}
+
 resource "google_pubsub_topic_iam_member" "crowdstrike_viewer" {
   count = var.infra_project_in_scope ? 1 : 0
 

--- a/modules/log-ingestion/variables.tf
+++ b/modules/log-ingestion/variables.tf
@@ -230,3 +230,9 @@ variable "labels" {
     error_message = "Maximum of 64 labels allowed per resource."
   }
 }
+
+variable "infra_project_in_scope" {
+  type        = bool
+  description = "Whether the infrastructure project is within the registration scope (used for conditional IAM permissions)"
+  default     = true
+}

--- a/modules/scope-checker/README.md
+++ b/modules/scope-checker/README.md
@@ -56,7 +56,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22"
     }
   }
 }
@@ -85,7 +85,7 @@ output "project_in_scope" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.22.0 |
 ## Resources
 
 | Name | Type |

--- a/modules/scope-checker/README.md
+++ b/modules/scope-checker/README.md
@@ -1,0 +1,106 @@
+# Scope Checker Module
+
+This module determines whether the infrastructure project is within the registration scope for folder-based registrations.
+
+## Purpose
+
+When registering a folder in GCP CSPM, the infrastructure project (where Pub/Sub resources are created) might be either:
+- Inside the registered folder scope (inherited permissions)  
+- Outside the registered folder scope (requires explicit project-level permissions)
+
+This module performs the scope check and returns a boolean result that other modules can use for conditional resource creation.
+
+## Usage
+
+```hcl
+module "scope-checker" {
+  source = "./modules/scope-checker/"
+
+  registration_type = "folder"
+  folder_ids        = ["123456789"]
+  infra_project_id  = "my-infra-project"
+}
+
+output "in_scope" {
+  value = module.scope-checker.infra_project_in_scope
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| registration_type | Registration scope (organization/folder/project) | `string` | n/a | yes |
+| folder_ids | List of folder IDs being registered | `list(string)` | `[]` | no |
+| infra_project_id | Infrastructure project ID | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| infra_project_in_scope | Whether the infra project is within registration scope |
+
+<!-- BEGIN_TF_DOCS -->
+# Scope Checker Module
+
+This module determines whether the infrastructure project is within the registration scope for folder-based registrations.
+
+When registering a folder in GCP CSPM, the infrastructure project (where Pub/Sub resources are created) might be either inside or outside the registered folder scope. This module performs the scope check and returns a boolean result for conditional IAM resource creation.
+
+## Usage
+
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "your-cspm-infrastructure-project"
+}
+
+module "scope_checker" {
+  source = "CrowdStrike/terraform-google-cloud-registration//modules/scope-checker"
+
+  # Registration configuration
+  registration_type = "folder"
+  folder_ids        = ["904504220746"]
+  infra_project_id  = "my-infra-project"
+}
+
+# Use the output to conditionally create resources
+output "project_in_scope" {
+  description = "Whether the infrastructure project is within registration scope"
+  value       = module.scope_checker.infra_project_in_scope
+}
+```
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0 |
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_project_ancestry.infra_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project_ancestry) | data source |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folders being registered | `list(string)` | `[]` | no |
+| <a name="input_infra_project_id"></a> [infra\_project\_id](#input\_infra\_project\_id) | Project ID used for CrowdStrike infrastructure resources | `string` | n/a | yes |
+| <a name="input_registration_type"></a> [registration\_type](#input\_registration\_type) | The scope of the Google Cloud registration which can be one of the following values: organization, folder, project | `string` | n/a | yes |
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_infra_project_in_scope"></a> [infra\_project\_in\_scope](#output\_infra\_project\_in\_scope) | Boolean indicating whether the infrastructure project is within the registration scope |
+<!-- END_TF_DOCS -->

--- a/modules/scope-checker/docs/.header.md
+++ b/modules/scope-checker/docs/.header.md
@@ -1,0 +1,5 @@
+# Scope Checker Module
+
+This module determines whether the infrastructure project is within the registration scope for folder-based registrations.
+
+When registering a folder in GCP CSPM, the infrastructure project (where Pub/Sub resources are created) might be either inside or outside the registered folder scope. This module performs the scope check and returns a boolean result for conditional IAM resource creation.

--- a/modules/scope-checker/docs/.usage.tf
+++ b/modules/scope-checker/docs/.usage.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "your-cspm-infrastructure-project"
+}
+
+module "scope_checker" {
+  source = "CrowdStrike/terraform-google-cloud-registration//modules/scope-checker"
+
+  # Registration configuration
+  registration_type = "folder"
+  folder_ids        = ["904504220746"]
+  infra_project_id  = "my-infra-project"
+}
+
+# Use the output to conditionally create resources
+output "project_in_scope" {
+  description = "Whether the infrastructure project is within registration scope"
+  value       = module.scope_checker.infra_project_in_scope
+}

--- a/modules/scope-checker/docs/.usage.tf
+++ b/modules/scope-checker/docs/.usage.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22"
     }
   }
 }

--- a/modules/scope-checker/main.tf
+++ b/modules/scope-checker/main.tf
@@ -1,0 +1,19 @@
+# Data source to check if infra_project_id is within folder registration scope
+data "google_project_ancestry" "infra_project" {
+  count   = var.registration_type == "folder" ? 1 : 0
+  project = var.infra_project_id
+}
+
+locals {
+  # Extract folder IDs from infra project's ancestors
+  infra_project_folder_ancestors = var.registration_type == "folder" ? [
+    for ancestor in data.google_project_ancestry.infra_project[0].ancestors :
+    ancestor.id if ancestor.type == "folder"
+  ] : []
+
+  # Check if any target folder is an ancestor of infra_project_id
+  infra_project_in_scope = var.registration_type == "folder" ? length(setintersection(
+    toset(var.folder_ids),
+    toset(local.infra_project_folder_ancestors)
+  )) > 0 : true
+}

--- a/modules/scope-checker/outputs.tf
+++ b/modules/scope-checker/outputs.tf
@@ -1,0 +1,4 @@
+output "infra_project_in_scope" {
+  description = "Boolean indicating whether the infrastructure project is within the registration scope"
+  value       = local.infra_project_in_scope
+}

--- a/modules/scope-checker/variables.tf
+++ b/modules/scope-checker/variables.tf
@@ -1,0 +1,32 @@
+variable "registration_type" {
+  type        = string
+  description = "The scope of the Google Cloud registration which can be one of the following values: organization, folder, project"
+
+  validation {
+    condition     = contains(["organization", "folder", "project"], var.registration_type)
+    error_message = "Registration type must be one of: organization, folder, project."
+  }
+}
+
+variable "folder_ids" {
+  type        = list(string)
+  description = "List of Google Cloud folders being registered"
+  default     = []
+
+  validation {
+    condition = length(var.folder_ids) == 0 || alltrue([
+      for folder_id in var.folder_ids : can(regex("^[1-9][0-9]*$", folder_id))
+    ])
+    error_message = "All folder IDs must be numeric strings without leading zeros."
+  }
+}
+
+variable "infra_project_id" {
+  type        = string
+  description = "Project ID used for CrowdStrike infrastructure resources"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.infra_project_id))
+    error_message = "Project ID must be 6-30 characters, start with lowercase letter, contain only lowercase letters/numbers/hyphens, and not end with hyphen."
+  }
+}

--- a/modules/scope-checker/versions.tf
+++ b/modules/scope-checker/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/scope-checker/versions.tf
+++ b/modules/scope-checker/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.22"
     }
     crowdstrike = {
       source  = "crowdstrike/crowdstrike"


### PR DESCRIPTION
Addresses CSPG-77653 by adding logic to handle Pub/Sub IAM permissions when the infrastructure project is located outside the registered folder scope. The solution conditionally grants project-level pubsub.viewer access when needed, while maintaining topic-level permissions for in-scope projects.