### PR TITLE
Add agentless scanning and DSPM support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
           - "examples/generic-registration"
           - "examples/infrastructure-manager"
           - "examples/native-terraform"
+          - "modules/agentless-scanning"
           - "modules/asset-inventory"
           - "modules/log-ingestion"
           - "modules/workload-identity"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,51 @@
-/.terraform.lock.hcl
-/terraform.tfvars
-/terraform.tfstate.backup
-/terraform.tfstate
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+.terraform.lock.hcl
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Development files
+Makefile
+.bin/
+
+# Ignore lock.hcl files created from updating documentation
+*.terraform.lock.hcl
+
+# IDE
+.idea/
+
+# Macos dummy files
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -113,10 +113,15 @@ module "crowdstrike_gcp_registration" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_agentless_scanning_role_arn"></a> [agentless\_scanning\_role\_arn](#input\_agentless\_scanning\_role\_arn) | AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable\_dspm is true. | `string` | `null` | no |
+| <a name="input_agentless_scanning_settings"></a> [agentless\_scanning\_settings](#input\_agentless\_scanning\_settings) | Configuration settings for agentless scanning infrastructure. Controls scanning scope, VPC, and network settings. | <pre>object({<br/>    host_project_id  = optional(string)<br/>    org_id           = optional(string)<br/>    regions          = optional(set(string), [])<br/>    deploy_cloud_nat = optional(bool, true)<br/>    custom_vpc_configuration = optional(object({<br/>      vpc_name = string<br/>      subnets  = map(string)<br/>    }))<br/>  })</pre> | `{}` | no |
 | <a name="input_deployment_method"></a> [deployment\_method](#input\_deployment\_method) | Deployment method for the CrowdStrike GCP registration | `string` | `"terraform-native"` | no |
+| <a name="input_enable_dspm"></a> [enable\_dspm](#input\_enable\_dspm) | Enable DSPM agentless scanning infrastructure | `bool` | `false` | no |
 | <a name="input_enable_realtime_visibility"></a> [enable\_realtime\_visibility](#input\_enable\_realtime\_visibility) | Enable Real Time Visibility and Detection (RTV&D) features via log ingestion | `bool` | `false` | no |
 | <a name="input_excluded_project_patterns"></a> [excluded\_project\_patterns](#input\_excluded\_project\_patterns) | List of shell-style patterns to exclude specific projects from CSPM registration. Supports wildcards (* and ?). Projects matching these patterns will be excluded from asset inventory and log ingestion. Examples: 'sys-*', 'dev-?'. | `list(string)` | `[]` | no |
-| <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folders being registered | `list(string)` | `[]` | no |
+| <a name="input_falcon_client_id"></a> [falcon\_client\_id](#input\_falcon\_client\_id) | Falcon API client ID. | `string` | `null` | no |
+| <a name="input_falcon_client_secret"></a> [falcon\_client\_secret](#input\_falcon\_client\_secret) | Falcon API client secret. | `string` | `null` | no |
+| <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folders being registered. When enable\_dspm = true, all folders must reside in the same organization. | `list(string)` | `[]` | no |
 | <a name="input_infra_project_id"></a> [infra\_project\_id](#input\_infra\_project\_id) | Google Cloud Project ID where CrowdStrike infrastructure resources will be deployed | `string` | n/a | yes |
 | <a name="input_infrastructure_manager_region"></a> [infrastructure\_manager\_region](#input\_infrastructure\_manager\_region) | The Google Cloud region for Infrastructure Manager. Required when deployment\_method is infrastructure-manager | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Map of labels to be applied to all resources created by this module | `map(string)` | `{}` | no |
@@ -125,14 +130,16 @@ module "crowdstrike_gcp_registration" {
 | <a name="input_project_ids"></a> [project\_ids](#input\_project\_ids) | List of Google Cloud projects being registered | `list(string)` | `[]` | no |
 | <a name="input_registration_name"></a> [registration\_name](#input\_registration\_name) | Name for the CrowdStrike GCP registration | `string` | n/a | yes |
 | <a name="input_registration_type"></a> [registration\_type](#input\_registration\_type) | Type of registration: organization, folder, or project | `string` | n/a | yes |
-| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix to be added to all created resource names for identification | `string` | `null` | no |
-| <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | Suffix to be added to all created resource names for identification | `string` | `null` | no |
+| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix to be added to all created resource names for identification. Combined length of prefix + suffix must not exceed 13 characters. | `string` | `null` | no |
+| <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | Suffix to be added to all created resource names for identification. Combined length of prefix + suffix must not exceed 13 characters. | `string` | `null` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | AWS Role ARN used by CrowdStrike for authentication | `string` | n/a | yes |
 | <a name="input_wif_project_id"></a> [wif\_project\_id](#input\_wif\_project\_id) | Google Cloud Project ID where the CrowdStrike workload identity federation pool resources are deployed. Defaults to infra\_project\_id if not specified | `string` | `null` | no |
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_agentless_scanning_sa_emails"></a> [agentless\_scanning\_sa\_emails](#output\_agentless\_scanning\_sa\_emails) | Agentless scanning Service Account emails per infra project (if DSPM enabled) |
+| <a name="output_agentless_scanning_wif_principal"></a> [agentless\_scanning\_wif\_principal](#output\_agentless\_scanning\_wif\_principal) | The agentless scanning WIF IAM principal (if DSPM enabled) |
 | <a name="output_log_sink_names"></a> [log\_sink\_names](#output\_log\_sink\_names) | Names of the created log sinks (if RTV&D enabled) |
 | <a name="output_log_subscription_id"></a> [log\_subscription\_id](#output\_log\_subscription\_id) | The ID of the Pub/Sub subscription for log ingestion (if RTV&D enabled) |
 | <a name="output_log_topic_id"></a> [log\_topic\_id](#output\_log\_topic\_id) | The ID of the Pub/Sub topic for log ingestion (if RTV&D enabled) |

--- a/examples/generic-registration/main.tf
+++ b/examples/generic-registration/main.tf
@@ -27,7 +27,12 @@ provider "crowdstrike" {
 # =============================================================================
 
 locals {
-  effective_wif_project_id = var.wif_project_id != null ? var.wif_project_id : var.infra_project_id
+  effective_wif_project_id   = var.wif_project_id != null ? var.wif_project_id : var.infra_project_id
+  agentless_is_cross_project = var.agentless_scanning_settings.host_project_id != null
+  network_configuration_type = (
+    var.agentless_scanning_settings.custom_vpc_configuration != null ? "custom" :
+    var.agentless_scanning_settings.deploy_cloud_nat ? "managed" : "managed_no_nat"
+  )
 }
 
 # Data source to get WIF project information
@@ -60,6 +65,10 @@ resource "crowdstrike_cloud_google_registration" "main" {
   realtime_visibility = var.enable_realtime_visibility ? {
     enabled = true
   } : null
+
+  dspm = {
+    enabled = var.enable_dspm
+  }
 }
 
 # =============================================================================
@@ -117,6 +126,36 @@ module "log-ingestion" {
   depends_on = [module.workload-identity]
 }
 
+module "agentless_scanning" {
+  count  = var.enable_dspm ? 1 : 0
+  source = "../../modules/agentless-scanning/"
+
+  registration_type = var.registration_type
+  registration_id   = crowdstrike_cloud_google_registration.main.id
+  host_project_id   = var.agentless_scanning_settings.host_project_id
+  project_ids       = var.project_ids
+  organization_id   = var.organization_id
+  folder_org_id     = var.agentless_scanning_settings.org_id
+  folder_ids        = var.folder_ids
+  labels            = var.labels
+  resource_prefix   = var.resource_prefix
+  resource_suffix   = var.resource_suffix
+
+  wif_project_number          = data.google_project.wif_project.number
+  wif_pool_id                 = module.workload-identity.wif_pool_id
+  agentless_scanning_role_arn = var.agentless_scanning_role_arn
+
+  falcon_client_id     = var.falcon_client_id
+  falcon_client_secret = var.falcon_client_secret
+
+  is_cross_project         = local.agentless_is_cross_project
+  regions                  = var.agentless_scanning_settings.regions
+  deploy_cloud_nat         = var.agentless_scanning_settings.deploy_cloud_nat
+  custom_vpc_configuration = var.agentless_scanning_settings.custom_vpc_configuration
+
+  depends_on = [module.workload-identity]
+}
+
 # =============================================================================
 # CrowdStrike Registration Settings
 # =============================================================================
@@ -129,10 +168,27 @@ resource "crowdstrike_cloud_google_registration_settings" "main" {
   log_ingestion_subscription_name = try(module.log-ingestion[0].subscription_name, null)
   log_ingestion_sink_name         = try(values(module.log-ingestion[0].log_sink_names)[0], null)
 
+  agentless_scanning_settings = var.enable_dspm ? {
+    wif_principal              = module.agentless_scanning[0].agentless_wif_principal
+    deployment_version         = module.agentless_scanning[0].deployment_version
+    regions                    = var.agentless_scanning_settings.regions
+    host_project_id            = local.agentless_is_cross_project ? var.agentless_scanning_settings.host_project_id : null
+    org_id                     = var.registration_type == "folder" ? var.agentless_scanning_settings.org_id : null
+    network_configuration_type = local.network_configuration_type
+
+    custom_network = var.agentless_scanning_settings.custom_vpc_configuration != null ? {
+      vpc_name = var.agentless_scanning_settings.custom_vpc_configuration.vpc_name
+      subnets  = var.agentless_scanning_settings.custom_vpc_configuration.subnets
+    } : null
+
+    infra = module.agentless_scanning[0].agentless_infra
+  } : null
+
   depends_on = [
     crowdstrike_cloud_google_registration.main,
     module.workload-identity,
     module.asset-inventory,
-    module.log-ingestion
+    module.log-ingestion,
+    module.agentless_scanning
   ]
 }

--- a/examples/generic-registration/main.tf
+++ b/examples/generic-registration/main.tf
@@ -27,8 +27,7 @@ provider "crowdstrike" {
 # =============================================================================
 
 locals {
-  effective_wif_project_id   = var.wif_project_id != null ? var.wif_project_id : var.infra_project_id
-  agentless_is_cross_project = var.agentless_scanning_settings.host_project_id != null
+  effective_wif_project_id = var.wif_project_id != null ? var.wif_project_id : var.infra_project_id
   network_configuration_type = (
     var.agentless_scanning_settings.custom_vpc_configuration != null ? "custom" :
     var.agentless_scanning_settings.deploy_cloud_nat ? "managed" : "managed_no_nat"
@@ -148,7 +147,6 @@ module "agentless_scanning" {
   falcon_client_id     = var.falcon_client_id
   falcon_client_secret = var.falcon_client_secret
 
-  is_cross_project         = local.agentless_is_cross_project
   regions                  = var.agentless_scanning_settings.regions
   deploy_cloud_nat         = var.agentless_scanning_settings.deploy_cloud_nat
   custom_vpc_configuration = var.agentless_scanning_settings.custom_vpc_configuration
@@ -172,7 +170,7 @@ resource "crowdstrike_cloud_google_registration_settings" "main" {
     wif_principal              = module.agentless_scanning[0].agentless_wif_principal
     deployment_version         = module.agentless_scanning[0].deployment_version
     regions                    = var.agentless_scanning_settings.regions
-    host_project_id            = local.agentless_is_cross_project ? var.agentless_scanning_settings.host_project_id : null
+    host_project_id            = var.agentless_scanning_settings.host_project_id
     org_id                     = var.registration_type == "folder" ? var.agentless_scanning_settings.org_id : null
     network_configuration_type = local.network_configuration_type
 

--- a/examples/generic-registration/variables.tf
+++ b/examples/generic-registration/variables.tf
@@ -138,6 +138,38 @@ variable "enable_realtime_visibility" {
   default     = false
 }
 
+variable "enable_dspm" {
+  type        = bool
+  description = "Enable DSPM agentless scanning infrastructure"
+  default     = false
+}
+
+variable "agentless_scanning_role_arn" {
+  type        = string
+  description = "AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable_dspm is true."
+  default     = null
+
+  validation {
+    condition     = var.agentless_scanning_role_arn == null || can(regex("^arn:(aws|aws-us-gov|aws-cn):(iam|sts)::[0-9]{12}:(role|assumed-role)/.+", var.agentless_scanning_role_arn))
+    error_message = "Agentless scanning Role ARN must be a valid AWS IAM role ARN or STS assumed role ARN format."
+  }
+}
+
+variable "agentless_scanning_settings" {
+  description = "Configuration settings for agentless scanning infrastructure. Controls scanning scope, VPC, and network settings."
+  type = object({
+    host_project_id  = optional(string)
+    org_id           = optional(string)
+    regions          = optional(set(string), [])
+    deploy_cloud_nat = optional(bool, true)
+    custom_vpc_configuration = optional(object({
+      vpc_name = string
+      subnets  = map(string)
+    }))
+  })
+  default = {}
+}
+
 # =============================================================================
 # RESOURCE NAMING & ORGANIZATION
 # =============================================================================

--- a/examples/infrastructure-manager/main.tf
+++ b/examples/infrastructure-manager/main.tf
@@ -78,4 +78,11 @@ module "crowdstrike_gcp_registration" {
 
   # Optional: Project exclusion patterns
   excluded_project_patterns = var.excluded_project_patterns
+
+  # Optional: Agentless scanning
+  enable_dspm                 = var.enable_dspm
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = local.falcon_client_secret
+  agentless_scanning_role_arn = var.agentless_scanning_role_arn
+  agentless_scanning_settings = var.agentless_scanning_settings
 }

--- a/examples/infrastructure-manager/outputs.tf
+++ b/examples/infrastructure-manager/outputs.tf
@@ -32,3 +32,8 @@ output "log_sink_names" {
   description = "Names of the created log sinks (if RTV&D enabled)"
   value       = module.crowdstrike_gcp_registration.log_sink_names
 }
+
+output "agentless_scanning_wif_principal" {
+  description = "The agentless scanning WIF IAM principal (if DSPM enabled)"
+  value       = module.crowdstrike_gcp_registration.agentless_scanning_wif_principal
+}

--- a/examples/infrastructure-manager/outputs.tf
+++ b/examples/infrastructure-manager/outputs.tf
@@ -32,8 +32,3 @@ output "log_sink_names" {
   description = "Names of the created log sinks (if RTV&D enabled)"
   value       = module.crowdstrike_gcp_registration.log_sink_names
 }
-
-output "agentless_scanning_wif_principal" {
-  description = "The agentless scanning WIF IAM principal (if DSPM enabled)"
-  value       = module.crowdstrike_gcp_registration.agentless_scanning_wif_principal
-}

--- a/examples/infrastructure-manager/variables.tf
+++ b/examples/infrastructure-manager/variables.tf
@@ -236,6 +236,42 @@ variable "log_ingestion_settings" {
   default = {}
 }
 
+# =============================================================================
+# AGENTLESS SCANNING SETTINGS
+# =============================================================================
+
+variable "enable_dspm" {
+  type        = bool
+  description = "Enable DSPM agentless scanning infrastructure"
+  default     = false
+}
+
+variable "agentless_scanning_role_arn" {
+  type        = string
+  description = "AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable_dspm is true."
+  default     = null
+
+  validation {
+    condition     = var.agentless_scanning_role_arn == null || can(regex("^arn:(aws|aws-us-gov|aws-cn):(iam|sts)::[0-9]{12}:(role|assumed-role)/.+", var.agentless_scanning_role_arn))
+    error_message = "Agentless scanning Role ARN must be a valid AWS IAM role ARN or STS assumed role ARN format."
+  }
+}
+
+variable "agentless_scanning_settings" {
+  description = "Configuration settings for agentless scanning infrastructure. Controls scanning scope, VPC, and network settings."
+  type = object({
+    host_project_id  = optional(string)
+    org_id           = optional(string)
+    regions          = optional(set(string), [])
+    deploy_cloud_nat = optional(bool, true)
+    custom_vpc_configuration = optional(object({
+      vpc_name = string
+      subnets  = map(string)
+    }))
+  })
+  default = {}
+}
+
 variable "falcon_cloud" {
   type        = string
   description = "CrowdStrike cloud environment. Set to 'us-gov-1' or 'us-gov-2' for government cloud deployments. Defaults to commercial cloud when null."

--- a/examples/native-terraform/main.tf
+++ b/examples/native-terraform/main.tf
@@ -58,4 +58,11 @@ module "crowdstrike_gcp_registration" {
 
   # Optional: Project exclusion patterns
   excluded_project_patterns = var.excluded_project_patterns
+
+  # Optional: Agentless scanning
+  enable_dspm                 = var.enable_dspm
+  falcon_client_id            = var.falcon_client_id
+  falcon_client_secret        = var.falcon_client_secret
+  agentless_scanning_role_arn = var.agentless_scanning_role_arn
+  agentless_scanning_settings = var.agentless_scanning_settings
 }

--- a/examples/native-terraform/outputs.tf
+++ b/examples/native-terraform/outputs.tf
@@ -5,6 +5,7 @@
 output "registration_id" {
   description = "The unique CrowdStrike registration ID for this GCP setup"
   value       = module.crowdstrike_gcp_registration.registration_id
+  sensitive   = true
 }
 
 output "wif_project_id" {
@@ -30,4 +31,9 @@ output "log_subscription_name" {
 output "log_sink_names" {
   description = "Names of the created log sinks (if RTV&D enabled)"
   value       = module.crowdstrike_gcp_registration.log_sink_names
+}
+
+output "agentless_scanning_wif_principal" {
+  description = "The agentless scanning WIF IAM principal (if DSPM enabled)"
+  value       = module.crowdstrike_gcp_registration.agentless_scanning_wif_principal
 }

--- a/examples/native-terraform/outputs.tf
+++ b/examples/native-terraform/outputs.tf
@@ -32,8 +32,3 @@ output "log_sink_names" {
   description = "Names of the created log sinks (if RTV&D enabled)"
   value       = module.crowdstrike_gcp_registration.log_sink_names
 }
-
-output "agentless_scanning_wif_principal" {
-  description = "The agentless scanning WIF IAM principal (if DSPM enabled)"
-  value       = module.crowdstrike_gcp_registration.agentless_scanning_wif_principal
-}

--- a/examples/native-terraform/variables.tf
+++ b/examples/native-terraform/variables.tf
@@ -218,6 +218,42 @@ variable "log_ingestion_settings" {
   default = {}
 }
 
+# =============================================================================
+# AGENTLESS SCANNING SETTINGS
+# =============================================================================
+
+variable "enable_dspm" {
+  type        = bool
+  description = "Enable DSPM agentless scanning infrastructure"
+  default     = false
+}
+
+variable "agentless_scanning_role_arn" {
+  type        = string
+  description = "AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable_dspm is true."
+  default     = null
+
+  validation {
+    condition     = var.agentless_scanning_role_arn == null || can(regex("^arn:(aws|aws-us-gov|aws-cn):(iam|sts)::[0-9]{12}:(role|assumed-role)/.+", var.agentless_scanning_role_arn))
+    error_message = "Agentless scanning Role ARN must be a valid AWS IAM role ARN or STS assumed role ARN format."
+  }
+}
+
+variable "agentless_scanning_settings" {
+  description = "Configuration settings for agentless scanning infrastructure. Controls scanning scope, VPC, and network settings."
+  type = object({
+    host_project_id  = optional(string)
+    org_id           = optional(string)
+    regions          = optional(set(string), [])
+    deploy_cloud_nat = optional(bool, true)
+    custom_vpc_configuration = optional(object({
+      vpc_name = string
+      subnets  = map(string)
+    }))
+  })
+  default = {}
+}
+
 variable "falcon_cloud" {
   type        = string
   description = "CrowdStrike cloud environment. Set to 'us-gov-1' or 'us-gov-2' for government cloud deployments. Defaults to commercial cloud when null."

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,12 @@
 locals {
-  effective_wif_project_id = var.wif_project_id != null ? var.wif_project_id : var.infra_project_id
-  effective_prefix         = var.resource_prefix != null ? var.resource_prefix : ""
-  effective_suffix         = var.resource_suffix != null ? var.resource_suffix : ""
+  effective_wif_project_id   = var.wif_project_id != null ? var.wif_project_id : var.infra_project_id
+  agentless_is_cross_project = var.agentless_scanning_settings.host_project_id != null
+  effective_prefix           = var.resource_prefix != null ? var.resource_prefix : ""
+  effective_suffix           = var.resource_suffix != null ? var.resource_suffix : ""
+  network_configuration_type = (
+    var.agentless_scanning_settings.custom_vpc_configuration != null ? "custom" :
+    var.agentless_scanning_settings.deploy_cloud_nat ? "managed" : "managed_no_nat"
+  )
 }
 
 # Data source to get WIF project information
@@ -11,8 +16,16 @@ data "google_project" "wif_project" {
 
 # CrowdStrike GCP registration resource
 resource "crowdstrike_cloud_google_registration" "main" {
-  name                          = var.registration_name
-  infra_project                 = var.infra_project_id
+  name          = var.registration_name
+  infra_project = var.infra_project_id
+
+  lifecycle {
+    precondition {
+      condition     = length(local.effective_prefix) + length(local.effective_suffix) <= 13
+      error_message = "Combined length of resource_prefix and resource_suffix must not exceed 13 characters."
+    }
+  }
+
   wif_project                   = local.effective_wif_project_id
   wif_project_number            = data.google_project.wif_project.number
   deployment_method             = var.deployment_method
@@ -33,6 +46,11 @@ resource "crowdstrike_cloud_google_registration" "main" {
   # Enable realtime visibility if requested
   realtime_visibility = {
     enabled = var.enable_realtime_visibility
+  }
+
+  # Enable dspm if requested
+  dspm = {
+    enabled = var.enable_dspm
   }
 
   # Project exclusion patterns
@@ -114,6 +132,40 @@ module "log-ingestion" {
   depends_on = [module.workload-identity, module.scope-checker]
 }
 
+module "agentless_scanning" {
+  count  = var.enable_dspm ? 1 : 0
+  source = "./modules/agentless-scanning/"
+
+  # Common vars from root
+  registration_type = var.registration_type
+  registration_id   = crowdstrike_cloud_google_registration.main.id
+  host_project_id   = var.agentless_scanning_settings.host_project_id
+  project_ids       = var.project_ids
+  organization_id   = var.organization_id
+  folder_org_id     = var.agentless_scanning_settings.org_id
+  folder_ids        = var.folder_ids
+  labels            = var.labels
+  resource_prefix   = local.effective_prefix
+  resource_suffix   = local.effective_suffix
+
+  # WIF info from shared pool
+  wif_project_number          = data.google_project.wif_project.number
+  wif_pool_id                 = module.workload-identity.wif_pool_id
+  agentless_scanning_role_arn = var.agentless_scanning_role_arn
+
+  # Falcon credentials (stored in Secret Manager per infra project)
+  falcon_client_id     = var.falcon_client_id
+  falcon_client_secret = var.falcon_client_secret
+
+  # Agentless scanning settings
+  is_cross_project         = local.agentless_is_cross_project
+  regions                  = var.agentless_scanning_settings.regions
+  deploy_cloud_nat         = var.agentless_scanning_settings.deploy_cloud_nat
+  custom_vpc_configuration = var.agentless_scanning_settings.custom_vpc_configuration
+
+  depends_on = [module.workload-identity]
+}
+
 # CrowdStrike registration settings
 resource "crowdstrike_cloud_google_registration_settings" "main" {
   registration_id                 = crowdstrike_cloud_google_registration.main.id
@@ -123,10 +175,27 @@ resource "crowdstrike_cloud_google_registration_settings" "main" {
   log_ingestion_subscription_name = try(module.log-ingestion[0].subscription_name, null)
   log_ingestion_sink_name         = try(values(module.log-ingestion[0].log_sink_names)[0], null)
 
+  agentless_scanning_settings = var.enable_dspm ? {
+    wif_principal              = module.agentless_scanning[0].agentless_wif_principal
+    deployment_version         = module.agentless_scanning[0].deployment_version
+    regions                    = var.agentless_scanning_settings.regions
+    host_project_id            = local.agentless_is_cross_project ? var.agentless_scanning_settings.host_project_id : null
+    org_id                     = var.registration_type == "folder" ? var.agentless_scanning_settings.org_id : null
+    network_configuration_type = local.network_configuration_type
+
+    custom_network = var.agentless_scanning_settings.custom_vpc_configuration != null ? {
+      vpc_name = var.agentless_scanning_settings.custom_vpc_configuration.vpc_name
+      subnets  = var.agentless_scanning_settings.custom_vpc_configuration.subnets
+    } : null
+
+    infra = module.agentless_scanning[0].agentless_infra
+  } : null
+
   depends_on = [
     crowdstrike_cloud_google_registration.main,
     module.workload-identity,
     module.asset-inventory,
-    module.log-ingestion
+    module.log-ingestion,
+    module.agentless_scanning
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,7 @@
 locals {
-  effective_wif_project_id   = var.wif_project_id != null ? var.wif_project_id : var.infra_project_id
-  agentless_is_cross_project = var.agentless_scanning_settings.host_project_id != null
-  effective_prefix           = var.resource_prefix != null ? var.resource_prefix : ""
-  effective_suffix           = var.resource_suffix != null ? var.resource_suffix : ""
+  effective_wif_project_id = var.wif_project_id != null ? var.wif_project_id : var.infra_project_id
+  effective_prefix         = var.resource_prefix != null ? var.resource_prefix : ""
+  effective_suffix         = var.resource_suffix != null ? var.resource_suffix : ""
   network_configuration_type = (
     var.agentless_scanning_settings.custom_vpc_configuration != null ? "custom" :
     var.agentless_scanning_settings.deploy_cloud_nat ? "managed" : "managed_no_nat"
@@ -158,7 +157,6 @@ module "agentless_scanning" {
   falcon_client_secret = var.falcon_client_secret
 
   # Agentless scanning settings
-  is_cross_project         = local.agentless_is_cross_project
   regions                  = var.agentless_scanning_settings.regions
   deploy_cloud_nat         = var.agentless_scanning_settings.deploy_cloud_nat
   custom_vpc_configuration = var.agentless_scanning_settings.custom_vpc_configuration
@@ -179,7 +177,7 @@ resource "crowdstrike_cloud_google_registration_settings" "main" {
     wif_principal              = module.agentless_scanning[0].agentless_wif_principal
     deployment_version         = module.agentless_scanning[0].deployment_version
     regions                    = var.agentless_scanning_settings.regions
-    host_project_id            = local.agentless_is_cross_project ? var.agentless_scanning_settings.host_project_id : null
+    host_project_id            = var.agentless_scanning_settings.host_project_id
     org_id                     = var.registration_type == "folder" ? var.agentless_scanning_settings.org_id : null
     network_configuration_type = local.network_configuration_type
 

--- a/modules/agentless-scanning/README.md
+++ b/modules/agentless-scanning/README.md
@@ -35,7 +35,6 @@ module "agentless_scanning" {
   # Project scope
   host_project_id  = "your-infrastructure-project"
   project_ids      = ["your-infrastructure-project"]
-  is_cross_project = false
 
   # Workload Identity Federation
   wif_project_number        = "123456789"
@@ -113,7 +112,6 @@ module "agentless_scanning" {
 | <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folder IDs for folder-level registration | `list(string)` | `[]` | no |
 | <a name="input_folder_org_id"></a> [folder\_org\_id](#input\_folder\_org\_id) | Parent GCP Organization ID of the registered folder(s). Required for folder registration to host the org-level scanner custom role bound at folder scope. | `string` | `null` | no |
 | <a name="input_host_project_id"></a> [host\_project\_id](#input\_host\_project\_id) | Google Cloud Project ID hosting the agentless scanning infrastructure (the host project). Set only in cross-project mode (org/folder/multi-project); null for per-project (no-cross) registrations where each project self-hosts. | `string` | `null` | no |
-| <a name="input_is_cross_project"></a> [is\_cross\_project](#input\_is\_cross\_project) | Cross-project scanning mode. true = 1 host project + targets get scan permissions only. false = every target project gets full scanning infra. Org/folder registrations must always be cross-project. | `bool` | `true` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Map of labels to be applied to all resources that support them | `map(string)` | `{}` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | GCP Organization ID for organization-level registration | `string` | `null` | no |
 | <a name="input_project_ids"></a> [project\_ids](#input\_project\_ids) | List of registered project IDs (full registration scope). Used for viewer role bindings and cross/no-cross target derivation. | `list(string)` | `[]` | no |

--- a/modules/agentless-scanning/README.md
+++ b/modules/agentless-scanning/README.md
@@ -1,0 +1,137 @@
+<!-- BEGIN_TF_DOCS -->
+![CrowdStrike Agentless Scanning Terraform Module for GCP](https://raw.githubusercontent.com/CrowdStrike/falconpy/main/docs/asset/cs-logo.png)
+
+[![Twitter URL](https://img.shields.io/twitter/url?label=Follow%20%40CrowdStrike&style=social&url=https%3A%2F%2Ftwitter.com%2FCrowdStrike)](https://twitter.com/CrowdStrike)
+
+## Introduction
+
+This Terraform module provisions Google Cloud infrastructure for CrowdStrike's agentless scanning capabilities (DSPM). It creates scanner service accounts, networking (VPC, subnets, optional Cloud NAT), IAM custom roles with least-privilege permissions, and Secret Manager secrets for Falcon credentials. The module supports single-project, multi-project (cross-project), folder, and organization registration scopes.
+
+## Usage
+
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.22"
+    }
+  }
+}
+
+provider "google" {
+  project = "your-infrastructure-project"
+}
+
+module "agentless_scanning" {
+  source = "CrowdStrike/terraform-google-cloud-registration//modules/agentless-scanning"
+
+  # Registration context
+  registration_type = "project"
+  registration_id   = "unique-registration-id"
+
+  # Project scope
+  host_project_id  = "your-infrastructure-project"
+  project_ids      = ["your-infrastructure-project"]
+  is_cross_project = false
+
+  # Workload Identity Federation
+  wif_project_number        = "123456789"
+  wif_pool_id               = "cs-wif-pool-12345"
+  agentless_scanning_role_arn = "arn:aws:sts::111111111111:assumed-role/CrowdStrikeScannerRole"
+
+  # Falcon credentials
+  falcon_client_id     = "<Falcon API client ID>"
+  falcon_client_secret = "<Falcon API client secret>"
+
+  # Scanning regions
+  regions = ["us-east1"]
+
+  # Optional: Resource naming
+  resource_prefix = "cs-"
+  resource_suffix = "-prod"
+}
+```
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.7.1 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_network.agentless_vpc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
+| [google_compute_router.agentless_router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
+| [google_compute_router_nat.agentless_nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
+| [google_compute_subnetwork.agentless_subnet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
+| [google_compute_subnetwork_iam_member.wif_byo_subnet_network_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam_member) | resource |
+| [google_compute_subnetwork_iam_member.wif_subnet_network_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam_member) | resource |
+| [google_folder_iam_member.folder_scanner_gcs_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.wif_viewer_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_organization_iam_custom_role.folder_scanner_gcs_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_custom_role.target_scanner_gcs_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_member.target_scanner_gcs_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_organization_iam_member.wif_viewer_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_project_iam_custom_role.scanner_gcs_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.target_scanner_gcs_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.wif_compute_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.scanner_gcs_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.target_scanner_gcs_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.wif_compute](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.wif_viewer_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.wif_viewer_roles_project_only](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_project_service.serviceusage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_secret_manager_secret.falcon_credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_iam_member.scanner_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_version.falcon_credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [google_service_account.scanner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_member.wif_can_use_scanner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [random_id.folder_org_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.gcs_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.infra_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.target_gcs_role_org_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.target_gcs_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [terraform_data.agentless_validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [google_compute_subnetwork.byo_validation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
+| [google_project_ancestry.host_project_scope_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project_ancestry) | data source |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_agentless_scanning_role_arn"></a> [agentless\_scanning\_role\_arn](#input\_agentless\_scanning\_role\_arn) | AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF | `string` | n/a | yes |
+| <a name="input_custom_vpc_configuration"></a> [custom\_vpc\_configuration](#input\_custom\_vpc\_configuration) | Custom VPC configuration for the host project. When set, uses the provided VPC/subnets instead of creating a managed VPC. vpc\_name = VPC name, subnets = {region = subnet\_name}. | <pre>object({<br/>    vpc_name = string<br/>    subnets  = map(string)<br/>  })</pre> | `null` | no |
+| <a name="input_deploy_cloud_nat"></a> [deploy\_cloud\_nat](#input\_deploy\_cloud\_nat) | Deploy Cloud NAT for scanner VMs. true = private IPs + NAT, false = public IPs. | `bool` | `true` | no |
+| <a name="input_falcon_client_id"></a> [falcon\_client\_id](#input\_falcon\_client\_id) | Falcon API client ID for scanner authentication | `string` | n/a | yes |
+| <a name="input_falcon_client_secret"></a> [falcon\_client\_secret](#input\_falcon\_client\_secret) | Falcon API client secret for scanner authentication | `string` | n/a | yes |
+| <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folder IDs for folder-level registration | `list(string)` | `[]` | no |
+| <a name="input_folder_org_id"></a> [folder\_org\_id](#input\_folder\_org\_id) | Parent GCP Organization ID of the registered folder(s). Required for folder registration to host the org-level scanner custom role bound at folder scope. | `string` | `null` | no |
+| <a name="input_host_project_id"></a> [host\_project\_id](#input\_host\_project\_id) | Google Cloud Project ID hosting the agentless scanning infrastructure (the host project). Set only in cross-project mode (org/folder/multi-project); null for per-project (no-cross) registrations where each project self-hosts. | `string` | `null` | no |
+| <a name="input_is_cross_project"></a> [is\_cross\_project](#input\_is\_cross\_project) | Cross-project scanning mode. true = 1 host project + targets get scan permissions only. false = every target project gets full scanning infra. Org/folder registrations must always be cross-project. | `bool` | `true` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Map of labels to be applied to all resources that support them | `map(string)` | `{}` | no |
+| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | GCP Organization ID for organization-level registration | `string` | `null` | no |
+| <a name="input_project_ids"></a> [project\_ids](#input\_project\_ids) | List of registered project IDs (full registration scope). Used for viewer role bindings and cross/no-cross target derivation. | `list(string)` | `[]` | no |
+| <a name="input_regions"></a> [regions](#input\_regions) | GCP regions to deploy scanner infrastructure (VPC, subnets, NAT). | `set(string)` | `[]` | no |
+| <a name="input_registration_id"></a> [registration\_id](#input\_registration\_id) | Unique registration ID from CrowdStrike backend. Used as suffix for resources with soft-delete lifecycle (SA, custom roles). | `string` | n/a | yes |
+| <a name="input_registration_type"></a> [registration\_type](#input\_registration\_type) | Type of registration: organization, folder, or project | `string` | n/a | yes |
+| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix to be added to created resource names | `string` | `""` | no |
+| <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | Suffix to be added to created resource names | `string` | `""` | no |
+| <a name="input_wif_pool_id"></a> [wif\_pool\_id](#input\_wif\_pool\_id) | Workload Identity Pool ID from the shared CSPM WIF pool | `string` | n/a | yes |
+| <a name="input_wif_project_number"></a> [wif\_project\_number](#input\_wif\_project\_number) | GCP Project Number for the WIF project (used in principal construction) | `string` | n/a | yes |
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_agentless_infra"></a> [agentless\_infra](#output\_agentless\_infra) | Per-project infrastructure map for agentless scanning provider settings |
+| <a name="output_agentless_wif_principal"></a> [agentless\_wif\_principal](#output\_agentless\_wif\_principal) | WIF Principal string for agentless scanning IAM bindings |
+| <a name="output_cross_target_ids"></a> [cross\_target\_ids](#output\_cross\_target\_ids) | Target project IDs with cross-project GCS scanning permissions |
+| <a name="output_deployment_version"></a> [deployment\_version](#output\_deployment\_version) | Module deployment version for BE tracking |
+| <a name="output_host_project_ids"></a> [host\_project\_ids](#output\_host\_project\_ids) | GCP host project IDs (single project in cross mode, multiple in no-cross) |
+| <a name="output_scanner_sa_emails"></a> [scanner\_sa\_emails](#output\_scanner\_sa\_emails) | Scanner Service Account emails per host project |
+<!-- END_TF_DOCS -->

--- a/modules/agentless-scanning/cross_targets.tf
+++ b/modules/agentless-scanning/cross_targets.tf
@@ -16,7 +16,7 @@ resource "google_organization_iam_custom_role" "target_scanner_gcs_role" {
   count = local.is_org_registration ? 1 : 0
 
   org_id      = var.organization_id
-  role_id     = "DSPMScannerGCSRead_${local.role_suffix}_${random_id.target_gcs_role_org_suffix[0].hex}"
+  role_id     = "${local.scanner_gcs_role.id_prefix}_${local.role_suffix}_${random_id.target_gcs_role_org_suffix[0].hex}"
   title       = local.scanner_gcs_role.title
   description = local.scanner_gcs_role.description
 
@@ -47,7 +47,7 @@ resource "google_project_iam_custom_role" "target_scanner_gcs_role" {
   for_each = toset(local.cross_target_ids)
 
   project     = each.value
-  role_id     = "DSPMScannerGCSRead_${local.role_suffix}_${random_id.target_gcs_role_suffix[each.value].hex}"
+  role_id     = "${local.scanner_gcs_role.id_prefix}_${local.role_suffix}_${random_id.target_gcs_role_suffix[each.value].hex}"
   title       = local.scanner_gcs_role.title
   description = local.scanner_gcs_role.description
 
@@ -77,7 +77,7 @@ resource "google_organization_iam_custom_role" "folder_scanner_gcs_role" {
   count = local.is_folder_registration ? 1 : 0
 
   org_id      = var.folder_org_id
-  role_id     = "DSPMScannerGCSRead_${local.role_suffix}_${random_id.folder_org_role_suffix[0].hex}"
+  role_id     = "${local.scanner_gcs_role.id_prefix}_${local.role_suffix}_${random_id.folder_org_role_suffix[0].hex}"
   title       = local.scanner_gcs_role.title
   description = local.scanner_gcs_role.description
 

--- a/modules/agentless-scanning/cross_targets.tf
+++ b/modules/agentless-scanning/cross_targets.tf
@@ -1,0 +1,93 @@
+# =============================================================================
+# Cross-Project Target Resources (cross mode only)
+# =============================================================================
+
+# =============================================================================
+# Org mode: single org-level custom role + binding
+# =============================================================================
+
+# Protects org-level target role against 44-day soft-delete collision
+resource "random_id" "target_gcs_role_org_suffix" {
+  count       = local.is_org_registration ? 1 : 0
+  byte_length = 4
+}
+
+resource "google_organization_iam_custom_role" "target_scanner_gcs_role" {
+  count = local.is_org_registration ? 1 : 0
+
+  org_id      = var.organization_id
+  role_id     = "DSPMScannerGCSRead_${local.role_suffix}_${random_id.target_gcs_role_org_suffix[0].hex}"
+  title       = local.scanner_gcs_role.title
+  description = local.scanner_gcs_role.description
+
+  permissions = local.scanner_gcs_role.permissions
+}
+
+resource "google_organization_iam_member" "target_scanner_gcs_permissions" {
+  count = local.is_org_registration ? 1 : 0
+
+  org_id = var.organization_id
+  role   = google_organization_iam_custom_role.target_scanner_gcs_role[0].id
+  member = "serviceAccount:${google_service_account.scanner_sa[var.host_project_id].email}"
+}
+
+# =============================================================================
+# Multi-project (standalone cross) mode: per-target-project custom role + binding
+# =============================================================================
+# Only used for project registrations in cross mode (cross_target_ids is empty
+# for org/folder, which bind a single org-level role instead).
+
+# Protects per-target-project role against 44-day soft-delete collision
+resource "random_id" "target_gcs_role_suffix" {
+  for_each    = toset(local.cross_target_ids)
+  byte_length = 4
+}
+
+resource "google_project_iam_custom_role" "target_scanner_gcs_role" {
+  for_each = toset(local.cross_target_ids)
+
+  project     = each.value
+  role_id     = "DSPMScannerGCSRead_${local.role_suffix}_${random_id.target_gcs_role_suffix[each.value].hex}"
+  title       = local.scanner_gcs_role.title
+  description = local.scanner_gcs_role.description
+
+  permissions = local.scanner_gcs_role.permissions
+}
+
+resource "google_project_iam_member" "target_scanner_gcs_permissions" {
+  for_each = toset(local.cross_target_ids)
+
+  project = each.value
+  role    = google_project_iam_custom_role.target_scanner_gcs_role[each.value].id
+  member  = "serviceAccount:${google_service_account.scanner_sa[var.host_project_id].email}"
+}
+
+# =============================================================================
+# Folder + cross + org-level role: single org role bound at folder level
+# =============================================================================
+# This avoids listing individual project IDs — the role is created at the org
+# and the binding at the folder inherits to all projects underneath.
+
+resource "random_id" "folder_org_role_suffix" {
+  count       = local.is_folder_registration ? 1 : 0
+  byte_length = 4
+}
+
+resource "google_organization_iam_custom_role" "folder_scanner_gcs_role" {
+  count = local.is_folder_registration ? 1 : 0
+
+  org_id      = var.folder_org_id
+  role_id     = "DSPMScannerGCSRead_${local.role_suffix}_${random_id.folder_org_role_suffix[0].hex}"
+  title       = local.scanner_gcs_role.title
+  description = local.scanner_gcs_role.description
+
+  permissions = local.scanner_gcs_role.permissions
+}
+
+resource "google_folder_iam_member" "folder_scanner_gcs_permissions" {
+  for_each = local.is_folder_registration ? toset(var.folder_ids) : toset([])
+
+  folder = "folders/${each.value}"
+  role   = google_organization_iam_custom_role.folder_scanner_gcs_role[0].id
+  member = "serviceAccount:${google_service_account.scanner_sa[var.host_project_id].email}"
+}

--- a/modules/agentless-scanning/docs/.header.md
+++ b/modules/agentless-scanning/docs/.header.md
@@ -1,0 +1,7 @@
+![CrowdStrike Agentless Scanning Terraform Module for GCP](https://raw.githubusercontent.com/CrowdStrike/falconpy/main/docs/asset/cs-logo.png)
+
+[![Twitter URL](https://img.shields.io/twitter/url?label=Follow%20%40CrowdStrike&style=social&url=https%3A%2F%2Ftwitter.com%2FCrowdStrike)](https://twitter.com/CrowdStrike)
+
+## Introduction
+
+This Terraform module provisions Google Cloud infrastructure for CrowdStrike's agentless scanning capabilities (DSPM). It creates scanner service accounts, networking (VPC, subnets, optional Cloud NAT), IAM custom roles with least-privilege permissions, and Secret Manager secrets for Falcon credentials. The module supports single-project, multi-project (cross-project), folder, and organization registration scopes.

--- a/modules/agentless-scanning/docs/.usage.tf
+++ b/modules/agentless-scanning/docs/.usage.tf
@@ -23,7 +23,6 @@ module "agentless_scanning" {
   # Project scope
   host_project_id  = "your-infrastructure-project"
   project_ids      = ["your-infrastructure-project"]
-  is_cross_project = false
 
   # Workload Identity Federation
   wif_project_number        = "123456789"

--- a/modules/agentless-scanning/docs/.usage.tf
+++ b/modules/agentless-scanning/docs/.usage.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.22"
+    }
+  }
+}
+
+provider "google" {
+  project = "your-infrastructure-project"
+}
+
+module "agentless_scanning" {
+  source = "CrowdStrike/terraform-google-cloud-registration//modules/agentless-scanning"
+
+  # Registration context
+  registration_type = "project"
+  registration_id   = "unique-registration-id"
+
+  # Project scope
+  host_project_id  = "your-infrastructure-project"
+  project_ids      = ["your-infrastructure-project"]
+  is_cross_project = false
+
+  # Workload Identity Federation
+  wif_project_number        = "123456789"
+  wif_pool_id               = "cs-wif-pool-12345"
+  agentless_scanning_role_arn = "arn:aws:sts::111111111111:assumed-role/CrowdStrikeScannerRole"
+
+  # Falcon credentials
+  falcon_client_id     = "<Falcon API client ID>"
+  falcon_client_secret = "<Falcon API client secret>"
+
+  # Scanning regions
+  regions = ["us-east1"]
+
+  # Optional: Resource naming
+  resource_prefix = "cs-"
+  resource_suffix = "-prod"
+}

--- a/modules/agentless-scanning/iam.tf
+++ b/modules/agentless-scanning/iam.tf
@@ -1,0 +1,160 @@
+# =============================================================================
+# IAM - Service Accounts, Custom Roles, Viewer Roles
+# =============================================================================
+
+# =============================================================================
+# Scanner Service Account (per host project)
+# =============================================================================
+
+# Protects SA and custom roles against soft-delete collisions
+resource "random_id" "infra_suffix" {
+  for_each    = toset(local.host_project_ids)
+  byte_length = 4
+}
+
+resource "google_service_account" "scanner_sa" {
+  for_each = toset(local.host_project_ids)
+
+  project      = each.value
+  account_id   = "${var.resource_prefix}csscan-${random_id.infra_suffix[each.value].hex}${var.resource_suffix}"
+  display_name = "Agentless Scanner SA"
+  description  = "Runs on scanner VM, has GCS read permissions"
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# =============================================================================
+# GCS IAM - Scanner SA Custom Role (per host project)
+# =============================================================================
+
+# Protects scanner_gcs_role against 44-day soft-delete collision
+resource "random_id" "gcs_role_suffix" {
+  for_each    = toset(local.host_project_ids)
+  byte_length = 4
+}
+
+resource "google_project_iam_custom_role" "scanner_gcs_role" {
+  for_each = toset(local.host_project_ids)
+
+  project     = each.value
+  role_id     = "DSPMScannerGCSRead_${local.role_suffix}_${random_id.gcs_role_suffix[each.value].hex}"
+  title       = local.scanner_gcs_role.title
+  description = local.scanner_gcs_role.description
+
+  permissions = local.scanner_gcs_role.permissions
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_project_iam_member" "scanner_gcs_permissions" {
+  for_each = toset(local.host_project_ids)
+
+  project = each.value
+  role    = google_project_iam_custom_role.scanner_gcs_role[each.value].id
+  member  = "serviceAccount:${google_service_account.scanner_sa[each.value].email}"
+}
+
+# =============================================================================
+# WIF Principal - Compute Manager Custom Role (per host project)
+# =============================================================================
+
+resource "google_project_iam_custom_role" "wif_compute_role" {
+  for_each = toset(local.host_project_ids)
+
+  project     = each.value
+  role_id     = "AgentlessComputeMgr_${local.role_suffix}_${random_id.infra_suffix[each.value].hex}"
+  title       = "Agentless Scanning Compute Manager"
+  description = "Minimal compute permissions for scanner VM lifecycle"
+
+  permissions = [
+    "compute.instances.create",
+    "compute.instances.delete",
+    "compute.instances.setMetadata",
+    "compute.instances.setServiceAccount",
+    "compute.instances.setLabels",
+    "compute.instances.start",
+    "compute.disks.create",
+    "compute.disks.delete",
+    "compute.disks.use",
+    "compute.images.useReadOnly",
+    "compute.zoneOperations.get",
+    "compute.instances.getSerialPortOutput",
+  ]
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# IAM Condition restricts mutations to CrowdStrike scanner resources only
+resource "google_project_iam_member" "wif_compute" {
+  for_each = toset(local.host_project_ids)
+
+  project = each.value
+  role    = google_project_iam_custom_role.wif_compute_role[each.value].id
+  member  = local.agentless_wif_principal
+
+  condition {
+    title       = "restrict-to-crowdstrike-scanner-resources"
+    description = "Limit mutations to CrowdStrike agentless scanner resources only"
+    expression = join(" || ", [
+      "(resource.type == \"compute.googleapis.com/Instance\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type == \"compute.googleapis.com/Disk\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type != \"compute.googleapis.com/Instance\" && resource.type != \"compute.googleapis.com/Disk\")",
+    ])
+  }
+}
+
+# WIF principal can use scanner SA (attach to VMs)
+resource "google_service_account_iam_member" "wif_can_use_scanner_sa" {
+  for_each = toset(local.host_project_ids)
+
+  service_account_id = google_service_account.scanner_sa[each.value].id
+  role               = "roles/iam.serviceAccountUser"
+  member             = local.agentless_wif_principal
+}
+
+# =============================================================================
+# WIF Principal - Viewer Roles (Read-Only Ops & Debug)
+# =============================================================================
+
+# Project registration: viewer roles on ALL registered projects
+resource "google_project_iam_member" "wif_viewer_roles" {
+  for_each = local.is_project_registration ? { for pair in setproduct(var.project_ids, tolist(setunion(local.viewer_roles, local.viewer_roles_project_only))) :
+    "${pair[0]}/${pair[1]}" => { project = pair[0], role = pair[1] }
+  } : {}
+
+  project = each.value.project
+  role    = each.value.role
+  member  = local.agentless_wif_principal
+}
+
+# Folder/Org mode: project-only roles bound on each host project
+resource "google_project_iam_member" "wif_viewer_roles_project_only" {
+  for_each = !local.is_project_registration ? {
+    for pair in setproduct(local.host_project_ids, tolist(local.viewer_roles_project_only)) :
+    "${pair[0]}/${pair[1]}" => { project = pair[0], role = pair[1] }
+  } : {}
+
+  project = each.value.project
+  role    = each.value.role
+  member  = local.agentless_wif_principal
+}
+
+# Folder mode: viewer roles at folder level (inherits to all child projects)
+resource "google_folder_iam_member" "wif_viewer_roles" {
+  for_each = local.is_folder_registration ? { for pair in setproduct(var.folder_ids, local.viewer_roles) :
+    "${pair[0]}/${pair[1]}" => { folder = pair[0], role = pair[1] }
+  } : {}
+
+  folder = "folders/${each.value.folder}"
+  role   = each.value.role
+  member = local.agentless_wif_principal
+}
+
+# Org mode: viewer roles at org level (inherits to all projects)
+resource "google_organization_iam_member" "wif_viewer_roles" {
+  for_each = local.is_org_registration ? local.viewer_roles : toset([])
+
+  org_id = var.organization_id
+  role   = each.value
+  member = local.agentless_wif_principal
+}

--- a/modules/agentless-scanning/iam.tf
+++ b/modules/agentless-scanning/iam.tf
@@ -37,7 +37,7 @@ resource "google_project_iam_custom_role" "scanner_gcs_role" {
   for_each = toset(local.host_project_ids)
 
   project     = each.value
-  role_id     = "DSPMScannerGCSRead_${local.role_suffix}_${random_id.gcs_role_suffix[each.value].hex}"
+  role_id     = "${local.scanner_gcs_role.id_prefix}_${local.role_suffix}_${random_id.gcs_role_suffix[each.value].hex}"
   title       = local.scanner_gcs_role.title
   description = local.scanner_gcs_role.description
 
@@ -127,15 +127,12 @@ resource "google_project_iam_member" "wif_viewer_roles" {
   member  = local.agentless_wif_principal
 }
 
-# Folder/Org mode: project-only roles bound on each host project
+# Folder/Org mode: project-only roles bound on the host project
 resource "google_project_iam_member" "wif_viewer_roles_project_only" {
-  for_each = !local.is_project_registration ? {
-    for pair in setproduct(local.host_project_ids, tolist(local.viewer_roles_project_only)) :
-    "${pair[0]}/${pair[1]}" => { project = pair[0], role = pair[1] }
-  } : {}
+  for_each = !local.is_project_registration ? local.viewer_roles_project_only : toset([])
 
-  project = each.value.project
-  role    = each.value.role
+  project = var.host_project_id
+  role    = each.value
   member  = local.agentless_wif_principal
 }
 

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -1,0 +1,224 @@
+# =============================================================================
+# Agentless Scanning Module
+# =============================================================================
+# Provisions GCP infrastructure for agentless scanning (DSPM, future: vulnerability scanning).
+#
+# Supports all registration modes:
+#   Single project:     host_project_id only
+#   Standalone cross:   host_project_id + project_ids (multi-project registration)
+#   Folder cross:       folder_ids + org-level custom role (cross-only, enforced)
+#   Org cross:          org_id + org-level custom role (cross-only, enforced)
+#
+# Org/Folder registrations are always cross-project (single host project, org-level IAM).
+# Project registrations support both cross and per-project modes.
+#
+# Creates: Scanner SA, VPC, Subnet, optional NAT, GCS IAM, custom roles
+# Does NOT create: Scanner VMs, Cloud SQL, BigQuery, Firestore
+# =============================================================================
+
+# =============================================================================
+# Locals
+# =============================================================================
+
+locals {
+  deployment_version = "1.0.0"
+
+  # Mode detection
+  is_org_registration     = var.registration_type == "organization"
+  is_folder_registration  = var.registration_type == "folder"
+  is_project_registration = var.registration_type == "project"
+
+  # WIF Principal - Agentless scanning (shared pool, different role ARN from CSPM)
+  agentless_wif_principal = "principal://iam.googleapis.com/projects/${var.wif_project_number}/locations/global/workloadIdentityPools/${var.wif_pool_id}/subject/${var.agentless_scanning_role_arn}/${var.registration_id}"
+
+  # Custom VPC mode detection
+  is_custom_vpc = var.custom_vpc_configuration != null
+
+  # Custom VPC subnet IAM pairs: flatten config into project/region pairs.
+  # Keyed off the single scanner infra project (see custom_vpc_project_id), not
+  # var.host_project_id, so single-project no-cross (host_project_id == null) works.
+  custom_vpc_subnet_pairs = local.is_custom_vpc ? {
+    for region, subnet in var.custom_vpc_configuration.subnets :
+    "${local.custom_vpc_project_id}/${region}" => { project = local.custom_vpc_project_id, region = region, subnetwork = subnet }
+  } : {}
+
+  # Registration ID truncated and sanitized for resource naming constraints:
+  # - Custom role_id: max 64 chars. Longest role "AgentlessComputeMgr" (19) + 2 separators + 8 hex = 29 overhead → 33-char reg_id fits (62 total)
+  # - SA account_id: max 30 chars. "csscan-" (7) + 8 hex + 13 (max prefix+suffix) = 28 → within limit
+  # We use the tighter constraint (23) for resource names, and 33 for role IDs.
+  role_suffix  = replace(substr(var.registration_id, 0, 33), "-", "_")
+  reg_id_short = substr(var.registration_id, 0, 23)
+
+  # Scanner GCS read role — reused across host project and cross-target roles at project/folder/org scope.
+  scanner_gcs_role = {
+    title       = "DSPM Scanner GCS Read"
+    description = "Minimal permissions for reading GCS objects in a given bucket"
+    permissions = [
+      "storage.objects.get",
+      "storage.objects.list",
+    ]
+  }
+
+  # -------------------------------------------------------------------------
+  # Project lists
+  # -------------------------------------------------------------------------
+
+  # Projects that need full scanning infra (SA, VPC, NAT, custom roles, APIs)
+  # - Cross-project (org/folder/multi-project): just the host project
+  # - Per-project (project scope only): ALL project_ids (each gets full infra)
+  host_project_ids = var.is_cross_project ? (var.host_project_id != null ? [var.host_project_id] : []) : var.project_ids
+
+  # The single project that owns the scanner VPC/subnets, used by custom (BYO) VPC.
+  # Custom VPC requires exactly one infra project: cross => the host project;
+  # single-project no-cross => that one project. one() errors if there is >1 infra
+  # project (multi-project no-cross), which custom VPC can't support — a cryptic
+  # last-line backstop. The root module's friendly precondition on
+  # crowdstrike_cloud_google_registration.main catches this first in normal use.
+  custom_vpc_project_id = one(local.host_project_ids)
+
+  # Projects that need scanning permissions only (cross mode targets for project registrations)
+  # - Org/Folder: empty (org-level role handles all targets automatically)
+  # - Project cross: project_ids minus host project
+  # - No-cross: empty (each project has own infra with self-scan)
+  cross_target_ids = !var.is_cross_project ? [] : (
+    (local.is_org_registration || local.is_folder_registration) ? [] : [
+      for project_id in var.project_ids : project_id if project_id != var.host_project_id
+    ]
+  )
+
+  # Sorted regions for deterministic CIDR assignment (sets are unordered)
+  sorted_regions = sort(tolist(var.regions))
+
+  # -------------------------------------------------------------------------
+  # Cross products for for_each iteration
+  # -------------------------------------------------------------------------
+
+  # APIs to enable per host project
+  api_list = toset([
+    "sts.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "compute.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "storage.googleapis.com",
+    "secretmanager.googleapis.com",
+    "cloudasset.googleapis.com",
+  ])
+
+  project_api_pairs = { for pair in setproduct(local.host_project_ids, local.api_list) :
+    "${pair[0]}/${pair[1]}" => { project = pair[0], api = pair[1] }
+  }
+
+  # Project × region pairs for subnet/router/NAT (managed VPC only)
+  project_region_pairs = local.is_custom_vpc ? {} : { for pair in setproduct(local.host_project_ids, local.sorted_regions) :
+    "${pair[0]}/${pair[1]}" => { project = pair[0], region = pair[1] }
+  }
+
+  # Same but only when NAT is enabled
+  project_region_nat_pairs = local.is_custom_vpc || !var.deploy_cloud_nat ? {} : local.project_region_pairs
+
+  # Viewer roles supported at all levels (project, folder, org)
+  viewer_roles = toset([
+    "roles/iam.securityReviewer",
+    "roles/compute.viewer",
+    "roles/monitoring.viewer",
+    "roles/logging.privateLogViewer",
+    "roles/cloudasset.viewer",
+    "roles/storage.insightsCollectorService",
+    "roles/secretmanager.viewer",
+    "roles/browser",
+  ])
+
+  # Viewer roles only supported at project level (GCP limitation)
+  viewer_roles_project_only = toset([
+    "roles/iam.roleViewer",
+  ])
+}
+
+# =============================================================================
+# Input Validation
+# =============================================================================
+
+resource "terraform_data" "agentless_validation" {
+  lifecycle {
+    precondition {
+      condition     = var.agentless_scanning_role_arn != null
+      error_message = "agentless_scanning_role_arn is required when enable_dspm = true."
+    }
+    precondition {
+      condition     = var.falcon_client_id != null && var.falcon_client_secret != null
+      error_message = "falcon_client_id and falcon_client_secret are required when enable_dspm = true."
+    }
+    precondition {
+      condition     = var.registration_type == "project" || var.is_cross_project
+      error_message = "Organization and folder registrations require cross-project mode (agentless_scanning_settings.host_project_id must be set)."
+    }
+    precondition {
+      condition = var.registration_type != "project" || (
+        var.host_project_id == null ? true : contains(var.project_ids, var.host_project_id)
+      )
+      error_message = "agentless_scanning_settings.host_project_id must be one of the registered project_ids for project registration."
+    }
+    precondition {
+      condition     = var.registration_type != "folder" || var.folder_org_id != null
+      error_message = "agentless_scanning_settings.org_id is required for folder registration when enable_dspm = true."
+    }
+    precondition {
+      condition     = var.custom_vpc_configuration == null || length(local.host_project_ids) == 1
+      error_message = "agentless_scanning_settings.custom_vpc_configuration requires exactly one scanner infra project: use cross-project mode (set host_project_id) or register a single project. Multi-project no-cross has one infra project per project_id and cannot share a single VPC."
+    }
+  }
+}
+
+# =============================================================================
+# Host Project Scope Validation
+# =============================================================================
+# For org/folder registrations, validates that the host project (where scanning
+# infra is deployed) actually belongs to the registered org or folder.
+# Skipped for project registrations (the agentless_validation precondition handles that).
+
+data "google_project_ancestry" "host_project_scope_check" {
+  count   = local.is_project_registration ? 0 : 1
+  project = var.host_project_id
+
+  lifecycle {
+    postcondition {
+      condition = local.is_org_registration ? contains(
+        [for a in self.ancestors : a.id if a.type == "organization"],
+        var.organization_id
+        ) : length(setintersection(
+          toset(var.folder_ids),
+          toset([for a in self.ancestors : a.id if a.type == "folder"])
+      )) > 0
+      error_message = "Host project '${var.host_project_id}' is not within the registered ${local.is_org_registration ? "organization '${var.organization_id}'" : "folder(s)"}."
+    }
+  }
+}
+
+# =============================================================================
+# API Services (per host project)
+# =============================================================================
+
+resource "google_project_service" "serviceusage" {
+  for_each = toset(local.host_project_ids)
+
+  project = each.value
+  service = "serviceusage.googleapis.com"
+
+  disable_dependent_services = false
+  disable_on_destroy         = false
+
+  depends_on = [data.google_project_ancestry.host_project_scope_check]
+}
+
+resource "google_project_service" "required_apis" {
+  for_each = local.project_api_pairs
+
+  project = each.value.project
+  service = each.value.api
+
+  disable_dependent_services = false
+  disable_on_destroy         = false
+
+  depends_on = [google_project_service.serviceusage]
+}

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -51,6 +51,7 @@ locals {
 
   # Scanner GCS read role — reused across host project and cross-target roles at project/folder/org scope.
   scanner_gcs_role = {
+    id_prefix   = "DSPMScannerGCSRead"
     title       = "DSPM Scanner GCS Read"
     description = "Minimal permissions for reading GCS objects in a given bucket"
     permissions = [
@@ -66,7 +67,7 @@ locals {
   # Projects that need full scanning infra (SA, VPC, NAT, custom roles, APIs)
   # - Cross-project (org/folder/multi-project): just the host project
   # - Per-project (project scope only): ALL project_ids (each gets full infra)
-  host_project_ids = var.is_cross_project ? (var.host_project_id != null ? [var.host_project_id] : []) : var.project_ids
+  host_project_ids = var.host_project_id != null ? [var.host_project_id] : var.project_ids
 
   # The single project that owns the scanner VPC/subnets, used by custom (BYO) VPC.
   # Custom VPC requires exactly one infra project: cross => the host project;
@@ -80,7 +81,7 @@ locals {
   # - Org/Folder: empty (org-level role handles all targets automatically)
   # - Project cross: project_ids minus host project
   # - No-cross: empty (each project has own infra with self-scan)
-  cross_target_ids = !var.is_cross_project ? [] : (
+  cross_target_ids = var.host_project_id == null ? [] : (
     (local.is_org_registration || local.is_folder_registration) ? [] : [
       for project_id in var.project_ids : project_id if project_id != var.host_project_id
     ]
@@ -150,7 +151,7 @@ resource "terraform_data" "agentless_validation" {
       error_message = "falcon_client_id and falcon_client_secret are required when enable_dspm = true."
     }
     precondition {
-      condition     = var.registration_type == "project" || var.is_cross_project
+      condition     = var.registration_type == "project" || var.host_project_id != null
       error_message = "Organization and folder registrations require cross-project mode (agentless_scanning_settings.host_project_id must be set)."
     }
     precondition {
@@ -162,10 +163,6 @@ resource "terraform_data" "agentless_validation" {
     precondition {
       condition     = var.registration_type != "folder" || var.folder_org_id != null
       error_message = "agentless_scanning_settings.org_id is required for folder registration when enable_dspm = true."
-    }
-    precondition {
-      condition     = !var.is_cross_project || var.host_project_id != null
-      error_message = "agentless_scanning_settings.host_project_id is required when cross-project mode is enabled."
     }
     precondition {
       condition     = var.custom_vpc_configuration == null || length(local.host_project_ids) == 1

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -164,6 +164,10 @@ resource "terraform_data" "agentless_validation" {
       error_message = "agentless_scanning_settings.org_id is required for folder registration when enable_dspm = true."
     }
     precondition {
+      condition     = !var.is_cross_project || var.host_project_id != null
+      error_message = "agentless_scanning_settings.host_project_id is required when cross-project mode is enabled."
+    }
+    precondition {
       condition     = var.custom_vpc_configuration == null || length(local.host_project_ids) == 1
       error_message = "agentless_scanning_settings.custom_vpc_configuration requires exactly one scanner infra project: use cross-project mode (set host_project_id) or register a single project. Multi-project no-cross has one infra project per project_id and cannot share a single VPC."
     }

--- a/modules/agentless-scanning/network.tf
+++ b/modules/agentless-scanning/network.tf
@@ -17,7 +17,7 @@ resource "google_compute_subnetwork" "agentless_subnet" {
 
   project       = each.value.project
   name          = "${var.resource_prefix}agentless-subnet-${each.value.region}${var.resource_suffix}"
-  ip_cidr_range = "10.${index(local.sorted_regions, each.value.region)}.0.0/24"
+  ip_cidr_range = "10.0.${index(local.sorted_regions, each.value.region)}.0/24"
   region        = each.value.region
   network       = google_compute_network.agentless_vpc[each.value.project].id
 

--- a/modules/agentless-scanning/network.tf
+++ b/modules/agentless-scanning/network.tf
@@ -17,7 +17,7 @@ resource "google_compute_subnetwork" "agentless_subnet" {
 
   project       = each.value.project
   name          = "${var.resource_prefix}agentless-subnet-${each.value.region}${var.resource_suffix}"
-  ip_cidr_range = "10.0.${index(local.sorted_regions, each.value.region)}.0/24"
+  ip_cidr_range = "10.${parseint(substr(md5(each.value.region), 0, 2), 16)}.${parseint(substr(md5(each.value.region), 2, 2), 16)}.0/24"
   region        = each.value.region
   network       = google_compute_network.agentless_vpc[each.value.project].id
 
@@ -71,7 +71,7 @@ resource "google_compute_subnetwork_iam_member" "wif_byo_subnet_network_user" {
 }
 
 # =============================================================================
-# Cloud Router + NAT (Managed VPC Only, Optional)
+# Cloud Router + NAT (Managed VPC Only, Recommended)
 # =============================================================================
 
 resource "google_compute_router" "agentless_router" {

--- a/modules/agentless-scanning/network.tf
+++ b/modules/agentless-scanning/network.tf
@@ -1,0 +1,95 @@
+# =============================================================================
+# VPC Network (Managed Mode Only, per host project)
+# =============================================================================
+
+resource "google_compute_network" "agentless_vpc" {
+  for_each = local.is_custom_vpc ? toset([]) : toset(local.host_project_ids)
+
+  project                 = each.value
+  name                    = "${var.resource_prefix}agentless-vpc${var.resource_suffix}"
+  auto_create_subnetworks = false
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_compute_subnetwork" "agentless_subnet" {
+  for_each = local.project_region_pairs
+
+  project       = each.value.project
+  name          = "${var.resource_prefix}agentless-subnet-${each.value.region}${var.resource_suffix}"
+  ip_cidr_range = "10.${index(local.sorted_regions, each.value.region)}.0.0/24"
+  region        = each.value.region
+  network       = google_compute_network.agentless_vpc[each.value.project].id
+
+  private_ip_google_access = true
+}
+
+# =============================================================================
+# Subnet-Level IAM - Network User (Managed VPC)
+# =============================================================================
+
+resource "google_compute_subnetwork_iam_member" "wif_subnet_network_user" {
+  for_each = local.project_region_pairs
+
+  project    = each.value.project
+  region     = each.value.region
+  subnetwork = google_compute_subnetwork.agentless_subnet[each.key].name
+  role       = "roles/compute.networkUser"
+  member     = local.agentless_wif_principal
+}
+
+# =============================================================================
+# Subnet-Level IAM - Network User (Custom VPC)
+# =============================================================================
+
+# Validate each provided subnet actually belongs to the named VPC. Fails fast at plan/apply.
+data "google_compute_subnetwork" "byo_validation" {
+  for_each = local.custom_vpc_subnet_pairs
+
+  project = each.value.project
+  region  = each.value.region
+  name    = each.value.subnetwork
+
+  lifecycle {
+    postcondition {
+      condition     = endswith(self.network, "/networks/${var.custom_vpc_configuration.vpc_name}")
+      error_message = "Subnet '${each.value.subnetwork}' (region '${each.value.region}') does not belong to VPC '${var.custom_vpc_configuration.vpc_name}'."
+    }
+  }
+}
+
+resource "google_compute_subnetwork_iam_member" "wif_byo_subnet_network_user" {
+  for_each = local.custom_vpc_subnet_pairs
+
+  project    = each.value.project
+  region     = each.value.region
+  subnetwork = each.value.subnetwork
+  role       = "roles/compute.networkUser"
+  member     = local.agentless_wif_principal
+
+  depends_on = [data.google_compute_subnetwork.byo_validation]
+}
+
+# =============================================================================
+# Cloud Router + NAT (Managed VPC Only, Optional)
+# =============================================================================
+
+resource "google_compute_router" "agentless_router" {
+  for_each = local.project_region_nat_pairs
+
+  project = each.value.project
+  name    = "${var.resource_prefix}agentless-router-${each.value.region}${var.resource_suffix}"
+  region  = each.value.region
+  network = google_compute_network.agentless_vpc[each.value.project].id
+}
+
+resource "google_compute_router_nat" "agentless_nat" {
+  for_each = local.project_region_nat_pairs
+
+  project                            = each.value.project
+  name                               = "${var.resource_prefix}agentless-nat-${each.value.region}${var.resource_suffix}"
+  router                             = google_compute_router.agentless_router[each.key].name
+  region                             = each.value.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}

--- a/modules/agentless-scanning/outputs.tf
+++ b/modules/agentless-scanning/outputs.tf
@@ -1,0 +1,51 @@
+output "agentless_wif_principal" {
+  description = "WIF Principal string for agentless scanning IAM bindings"
+  value       = local.agentless_wif_principal
+}
+
+output "scanner_sa_emails" {
+  description = "Scanner Service Account emails per host project"
+  value = {
+    for project_id in local.host_project_ids :
+    project_id => google_service_account.scanner_sa[project_id].email
+  }
+}
+
+output "host_project_ids" {
+  description = "GCP host project IDs (single project in cross mode, multiple in no-cross)"
+  value       = local.host_project_ids
+}
+
+output "cross_target_ids" {
+  description = "Target project IDs with cross-project GCS scanning permissions"
+  value       = local.cross_target_ids
+}
+
+output "deployment_version" {
+  description = "Module deployment version for BE tracking"
+  value       = local.deployment_version
+}
+
+output "agentless_infra" {
+  description = "Per-project infrastructure map for agentless scanning provider settings"
+  value = {
+    for project_id in local.host_project_ids :
+    project_id => {
+      scanner_sa_email               = google_service_account.scanner_sa[project_id].email
+      client_credentials_secret_name = google_secret_manager_secret.falcon_credentials[project_id].secret_id
+      network = {
+        vpc_name = (local.is_custom_vpc
+          ? var.custom_vpc_configuration.vpc_name
+          : google_compute_network.agentless_vpc[project_id].name
+        )
+        subnets = (local.is_custom_vpc
+          ? var.custom_vpc_configuration.subnets
+          : {
+            for region in var.regions :
+            region => google_compute_subnetwork.agentless_subnet["${project_id}/${region}"].name
+          }
+        )
+      }
+    }
+  }
+}

--- a/modules/agentless-scanning/secrets.tf
+++ b/modules/agentless-scanning/secrets.tf
@@ -1,0 +1,37 @@
+# =============================================================================
+# Secret Manager - Falcon Client Credentials (per host project)
+# =============================================================================
+
+resource "google_secret_manager_secret" "falcon_credentials" {
+  for_each = toset(local.host_project_ids)
+
+  project   = each.value
+  secret_id = "${var.resource_prefix}csscanning-falcon-credentials-${local.reg_id_short}${var.resource_suffix}"
+
+  labels = var.labels
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_secret_manager_secret_version" "falcon_credentials" {
+  for_each = toset(local.host_project_ids)
+
+  secret = google_secret_manager_secret.falcon_credentials[each.value].id
+  secret_data = jsonencode({
+    clientId     = var.falcon_client_id
+    clientSecret = var.falcon_client_secret
+  })
+}
+
+resource "google_secret_manager_secret_iam_member" "scanner_access" {
+  for_each = toset(local.host_project_ids)
+
+  project   = each.value
+  secret_id = google_secret_manager_secret.falcon_credentials[each.value].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.scanner_sa[each.value].email}"
+}

--- a/modules/agentless-scanning/variables.tf
+++ b/modules/agentless-scanning/variables.tf
@@ -1,0 +1,209 @@
+# =============================================================================
+# Agentless Scanning Module - Variables
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Common (passed from root module)
+# -----------------------------------------------------------------------------
+
+variable "registration_type" {
+  type        = string
+  description = "Type of registration: organization, folder, or project"
+
+  validation {
+    condition     = contains(["organization", "folder", "project"], var.registration_type)
+    error_message = "Registration type must be one of: organization, folder, project."
+  }
+}
+
+variable "registration_id" {
+  type        = string
+  description = "Unique registration ID from CrowdStrike backend. Used as suffix for resources with soft-delete lifecycle (SA, custom roles)."
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.registration_id))
+    error_message = "Registration ID must contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "host_project_id" {
+  type        = string
+  description = "Google Cloud Project ID hosting the agentless scanning infrastructure (the host project). Set only in cross-project mode (org/folder/multi-project); null for per-project (no-cross) registrations where each project self-hosts."
+  default     = null
+
+  validation {
+    condition     = var.host_project_id == null ? true : (length(var.host_project_id) >= 6 && length(var.host_project_id) <= 30 && can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.host_project_id)))
+    error_message = "Host project ID must be 6-30 characters, start with a lowercase letter, contain only lowercase letters, numbers, and hyphens, and not end with a hyphen."
+  }
+}
+
+variable "project_ids" {
+  type        = list(string)
+  description = "List of registered project IDs (full registration scope). Used for viewer role bindings and cross/no-cross target derivation."
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for project_id in var.project_ids : length(project_id) >= 6 && length(project_id) <= 30 && can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", project_id))
+    ])
+    error_message = "All project IDs must be 6-30 characters, start with lowercase letter, contain only lowercase letters/numbers/hyphens, and not end with hyphen."
+  }
+}
+
+variable "organization_id" {
+  type        = string
+  description = "GCP Organization ID for organization-level registration"
+  default     = null
+
+  validation {
+    condition     = var.organization_id == null || can(regex("^[1-9][0-9]*$", var.organization_id))
+    error_message = "Organization ID must be a numeric string without leading zeros when provided."
+  }
+}
+
+variable "folder_org_id" {
+  type        = string
+  description = "Parent GCP Organization ID of the registered folder(s). Required for folder registration to host the org-level scanner custom role bound at folder scope."
+  default     = null
+
+  validation {
+    condition     = var.folder_org_id == null || can(regex("^[1-9][0-9]*$", var.folder_org_id))
+    error_message = "Folder org ID must be a numeric string without leading zeros when provided."
+  }
+}
+
+variable "folder_ids" {
+  type        = list(string)
+  description = "List of Google Cloud folder IDs for folder-level registration"
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for folder_id in var.folder_ids : can(regex("^[1-9][0-9]*$", folder_id))
+    ])
+    error_message = "All folder IDs must be numeric strings without leading zeros."
+  }
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Map of labels to be applied to all resources that support them"
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for key, value in var.labels : can(regex("^[a-z][a-z0-9_-]{0,62}$", key))
+    ])
+    error_message = "Label keys must start with lowercase letter, contain only lowercase letters, numbers, hyphens, and underscores, and be 1-63 characters long."
+  }
+
+  validation {
+    condition = alltrue([
+      for key, value in var.labels : can(regex("^[a-z0-9_-]{0,63}$", value))
+    ])
+    error_message = "Label values must contain only lowercase letters, numbers, hyphens, and underscores, and be 0-63 characters long."
+  }
+
+  validation {
+    condition     = length(var.labels) <= 64
+    error_message = "Maximum of 64 labels allowed per resource."
+  }
+}
+
+variable "resource_prefix" {
+  type        = string
+  description = "Prefix to be added to created resource names"
+  default     = ""
+}
+
+variable "resource_suffix" {
+  type        = string
+  description = "Suffix to be added to created resource names"
+  default     = ""
+}
+
+# -----------------------------------------------------------------------------
+# WIF (from workload-identity module outputs)
+# -----------------------------------------------------------------------------
+
+variable "wif_project_number" {
+  type        = string
+  description = "GCP Project Number for the WIF project (used in principal construction)"
+}
+
+variable "wif_pool_id" {
+  type        = string
+  description = "Workload Identity Pool ID from the shared CSPM WIF pool"
+}
+
+variable "agentless_scanning_role_arn" {
+  type        = string
+  description = "AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF"
+
+  validation {
+    condition     = can(regex("^arn:(aws|aws-us-gov|aws-cn):(iam|sts)::[0-9]{12}:(role|assumed-role)/.+", var.agentless_scanning_role_arn))
+    error_message = "Agentless scanning Role ARN must be a valid AWS IAM role ARN or STS assumed role ARN format."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Falcon Credentials (stored in Secret Manager per host project)
+# -----------------------------------------------------------------------------
+
+variable "falcon_client_id" {
+  type        = string
+  sensitive   = true
+  description = "Falcon API client ID for scanner authentication"
+}
+
+variable "falcon_client_secret" {
+  type        = string
+  sensitive   = true
+  description = "Falcon API client secret for scanner authentication"
+}
+
+# -----------------------------------------------------------------------------
+# Agentless Scanning Configuration
+# -----------------------------------------------------------------------------
+
+variable "is_cross_project" {
+  type        = bool
+  description = "Cross-project scanning mode. true = 1 host project + targets get scan permissions only. false = every target project gets full scanning infra. Org/folder registrations must always be cross-project."
+  default     = true
+}
+
+
+# -----------------------------------------------------------------------------
+# Network Configuration
+# -----------------------------------------------------------------------------
+
+variable "regions" {
+  type        = set(string)
+  description = "GCP regions to deploy scanner infrastructure (VPC, subnets, NAT)."
+  default     = []
+
+  validation {
+    condition     = length(var.regions) > 0
+    error_message = "At least one region must be specified."
+  }
+
+  validation {
+    condition     = alltrue([for r in var.regions : can(regex("^[a-z]+-[a-z]+[0-9]+$", r))])
+    error_message = "Each region must be a valid GCP region format (e.g., 'us-east1', 'europe-west4', 'asia-southeast1')."
+  }
+}
+
+variable "deploy_cloud_nat" {
+  type        = bool
+  description = "Deploy Cloud NAT for scanner VMs. true = private IPs + NAT, false = public IPs."
+  default     = true
+}
+
+variable "custom_vpc_configuration" {
+  type = object({
+    vpc_name = string
+    subnets  = map(string)
+  })
+  description = "Custom VPC configuration for the host project. When set, uses the provided VPC/subnets instead of creating a managed VPC. vpc_name = VPC name, subnets = {region = subnet_name}."
+  default     = null
+}

--- a/modules/agentless-scanning/variables.tf
+++ b/modules/agentless-scanning/variables.tf
@@ -129,6 +129,10 @@ variable "resource_suffix" {
 variable "wif_project_number" {
   type        = string
   description = "GCP Project Number for the WIF project (used in principal construction)"
+  validation {
+    condition     = can(regex("^[0-9]+$", var.wif_project_number))
+    error_message = "WIF project number must be a numeric string."
+  }
 }
 
 variable "wif_pool_id" {
@@ -154,6 +158,10 @@ variable "falcon_client_id" {
   type        = string
   sensitive   = true
   description = "Falcon API client ID for scanner authentication"
+  validation {
+    condition     = length(var.falcon_client_id) == 32 && can(regex("^[a-fA-F0-9]+$", var.falcon_client_id))
+    error_message = "falcon_client_id must be a 32-character hexadecimal string. Please use the Falcon console to generate a new API key/secret pair with appropriate scopes."
+  }
 }
 
 variable "falcon_client_secret" {

--- a/modules/agentless-scanning/variables.tf
+++ b/modules/agentless-scanning/variables.tf
@@ -171,17 +171,6 @@ variable "falcon_client_secret" {
 }
 
 # -----------------------------------------------------------------------------
-# Agentless Scanning Configuration
-# -----------------------------------------------------------------------------
-
-variable "is_cross_project" {
-  type        = bool
-  description = "Cross-project scanning mode. true = 1 host project + targets get scan permissions only. false = every target project gets full scanning infra. Org/folder registrations must always be cross-project."
-  default     = true
-}
-
-
-# -----------------------------------------------------------------------------
 # Network Configuration
 # -----------------------------------------------------------------------------
 

--- a/modules/agentless-scanning/versions.tf
+++ b/modules/agentless-scanning/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.7.1"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,3 +59,17 @@ output "log_sink_names" {
   description = "Names of the created log sinks (if RTV&D enabled)"
   value       = var.enable_realtime_visibility ? module.log-ingestion[0].log_sink_names : null
 }
+
+# =============================================================================
+# Agentless Scanning Outputs (Optional - only when DSPM is enabled)
+# =============================================================================
+
+output "agentless_scanning_wif_principal" {
+  description = "The agentless scanning WIF IAM principal (if DSPM enabled)"
+  value       = var.enable_dspm ? module.agentless_scanning[0].agentless_wif_principal : null
+}
+
+output "agentless_scanning_sa_emails" {
+  description = "Agentless scanning Service Account emails per infra project (if DSPM enabled)"
+  value       = var.enable_dspm ? module.agentless_scanning[0].scanner_sa_emails : null
+}

--- a/scripts/service-account-setup.sh
+++ b/scripts/service-account-setup.sh
@@ -21,6 +21,8 @@ usage() {
     echo "Optional parameters:"
     echo "  --wif-project-id      GCP project ID for Workload Identity Federation (default: same as infra-project-id)"
     echo "  --enable-rtvd         Enable Real Time Visibility & Detection (default: false)"
+    echo "  --enable-dspm         Enable DSPM agentless scanning (default: false)"
+    echo "  --agentless-org-id    Organization ID for agentless scanning (required for folder registration with --enable-dspm)"
     echo "  --location            Infrastructure Manager location (default: us-central1)"
     echo "  --help                Show this help message"
     echo ""
@@ -39,6 +41,8 @@ usage() {
 REGISTRATION_TYPE=""
 PROJECT_ID=""
 ENABLE_RTVD=false
+ENABLE_DSPM=false
+AGENTLESS_ORG_ID=""
 ORGANIZATION_ID=""
 FOLDER_IDS=""
 TARGET_PROJECTS=""
@@ -60,6 +64,14 @@ while [[ $# -gt 0 ]]; do
         --enable-rtvd)
             ENABLE_RTVD=true
             shift
+            ;;
+        --enable-dspm)
+            ENABLE_DSPM=true
+            shift
+            ;;
+        --agentless-org-id)
+            AGENTLESS_ORG_ID="$2"
+            shift 2
             ;;
         --organization-id)
             ORGANIZATION_ID="$2"
@@ -241,6 +253,23 @@ if [[ "$ENABLE_RTVD" == true ]]; then
     fi
 fi
 
+# Add DSPM project roles if enabled
+if [[ "$ENABLE_DSPM" == true ]]; then
+    PROJECT_ROLES+=(
+        "roles/compute.networkAdmin"
+        "roles/iam.serviceAccountAdmin"
+        "roles/iam.roleAdmin"
+        "roles/secretmanager.admin"
+    )
+
+    # DSPM needs projectIamAdmin for IAM bindings on infra project
+    if [[ "$REGISTRATION_TYPE" == "project" ]]; then
+        PROJECT_ROLES+=(
+            "roles/resourcemanager.projectIamAdmin"
+        )
+    fi
+fi
+
 # Apply project-level roles
 echo "Applying project-level roles..."
 for role in "${PROJECT_ROLES[@]}"; do
@@ -275,6 +304,23 @@ if [[ "$REGISTRATION_TYPE" == "folder" ]]; then
         )
     fi
 
+    # Add DSPM folder roles (for cross-project IAM bindings on target projects)
+    if [[ "$ENABLE_DSPM" == true ]]; then
+        FOLDER_ROLES+=(
+            "roles/resourcemanager.projectIamAdmin"
+        )
+
+        # Folder+DSPM needs org-level role for custom role creation
+        if [[ -n "$AGENTLESS_ORG_ID" ]]; then
+            echo "  Binding roles/iam.organizationRoleAdmin to organization $AGENTLESS_ORG_ID..."
+            gcloud organizations add-iam-policy-binding $AGENTLESS_ORG_ID \
+                --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
+                --role="roles/iam.organizationRoleAdmin" \
+                --condition=None
+            sleep 3
+        fi
+    fi
+
     # Process multiple folders
     IFS=',' read -ra FOLDER_ARRAY <<< "$FOLDER_IDS"
     for folder in "${FOLDER_ARRAY[@]}"; do
@@ -305,6 +351,14 @@ if [[ "$REGISTRATION_TYPE" == "organization" ]]; then
     if [[ "$ENABLE_RTVD" == true ]]; then
         ORG_ROLES+=(
             "roles/logging.configWriter"
+        )
+    fi
+
+    # Add DSPM org roles (for org-level custom role creation)
+    if [[ "$ENABLE_DSPM" == true ]]; then
+        ORG_ROLES+=(
+            "roles/iam.organizationRoleAdmin"
+            "roles/resourcemanager.projectIamAdmin"
         )
     fi
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,19 +20,19 @@ variable "wif_project_id" {
 }
 
 variable "resource_prefix" {
-  description = "Prefix to be added to all created resource names for identification"
+  description = "Prefix to be added to all created resource names for identification. Combined length of prefix + suffix must not exceed 13 characters."
   default     = null
   type        = string
 
   validation {
     condition     = var.resource_prefix == null || var.resource_prefix == "" || (can(regex("^[A-Za-z0-9][A-Za-z0-9_.-]*$", var.resource_prefix)) && length(var.resource_prefix) <= 13)
-    error_message = "Resource prefix must start with alphanumeric character and contain only letters, numbers, underscores, hyphens, and periods, and be 13 characters or less."
+    error_message = "Resource prefix must start with alphanumeric character, contain only letters, numbers, underscores, hyphens, and periods, and be 13 characters or less."
   }
 }
 
 variable "resource_suffix" {
   type        = string
-  description = "Suffix to be added to all created resource names for identification"
+  description = "Suffix to be added to all created resource names for identification. Combined length of prefix + suffix must not exceed 13 characters."
   default     = null
 
   validation {
@@ -100,7 +100,7 @@ variable "organization_id" {
 
 variable "folder_ids" {
   type        = list(string)
-  description = "List of Google Cloud folders being registered"
+  description = "List of Google Cloud folders being registered. When enable_dspm = true, all folders must reside in the same organization."
   default     = []
 
   validation {
@@ -166,6 +166,52 @@ variable "excluded_project_patterns" {
     ])
     error_message = "All excluded project patterns must be non-empty strings."
   }
+}
+
+variable "enable_dspm" {
+  type        = bool
+  description = "Enable DSPM agentless scanning infrastructure"
+  default     = false
+}
+
+variable "falcon_client_id" {
+  type        = string
+  description = "Falcon API client ID."
+  sensitive   = true
+  default     = null
+}
+
+variable "falcon_client_secret" {
+  type        = string
+  description = "Falcon API client secret."
+  sensitive   = true
+  default     = null
+}
+
+variable "agentless_scanning_role_arn" {
+  type        = string
+  description = "AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable_dspm is true."
+  default     = null
+
+  validation {
+    condition     = var.agentless_scanning_role_arn == null || can(regex("^arn:(aws|aws-us-gov|aws-cn):(iam|sts)::[0-9]{12}:(role|assumed-role)/.+", var.agentless_scanning_role_arn))
+    error_message = "Agentless scanning Role ARN must be a valid AWS IAM role ARN or STS assumed role ARN format."
+  }
+}
+
+variable "agentless_scanning_settings" {
+  description = "Configuration settings for agentless scanning infrastructure. Controls scanning scope, VPC, and network settings."
+  type = object({
+    host_project_id  = optional(string)
+    org_id           = optional(string)
+    regions          = optional(set(string), [])
+    deploy_cloud_nat = optional(bool, true)
+    custom_vpc_configuration = optional(object({
+      vpc_name = string
+      subnets  = map(string)
+    }))
+  })
+  default = {}
 }
 
 variable "log_ingestion_settings" {


### PR DESCRIPTION
# Add agentless scanning and DSPM support

## Summary
- Add a new `agentless-scanning` module that provisions the GCP infrastructure for DSPM / agentless scanning (IAM roles & bindings, networking, cross-project scan targets, and outputs).
- Store Falcon client credentials in per-project Secret Manager secrets, granting the scanner service account `secretmanager.secretAccessor`.
- Wire DSPM into the root module (`main.tf`, `variables.tf`, `outputs.tf`) behind an `enable_dspm` toggle, with validation requiring `falcon_client_id` / `falcon_client_secret` when enabled.
- Update the `generic-registration`, `infrastructure-manager`, and `native-terraform` examples to demonstrate enabling DSPM.
- Update `scripts/service-account-setup.sh`, CI workflow, and `.gitignore` accordingly.

## Test plan

### Terraform Apply / Plan / Destroy
- [x] `terraform init` succeeds with required provider constraints
- [x] `terraform plan` produces a clean plan with no errors across all configurations
- [x] `terraform apply` completes successfully for all scenarios below (107–110 resources depending on config)
- [x] `terraform destroy -auto-approve` cleanly removes all resources with zero leftover
- [x] Re-apply after destroy produces an identical resource set (no drift)

### Scenario Matrix

**Single Project, Managed Network**
- [x] Single project, DSPM enabled, managed VPC, 1 region — apply + verify + destroy
- [x] Single project, DSPM enabled, managed VPC, 3 regions (us-east1, us-west1, us-central1) — apply + verify + destroy

**Multi-Project, BYO Network**
- [x] Two-project, DSPM enabled, managed VPC, 1 region — apply + verify
- [x] In-place modify: managed VPC → BYO VPC (custom network), change host project, change regions — apply (24 added, 1 changed, 27 destroyed)
- [x] Two-project, DSPM enabled, BYO VPC, 2 regions, `deploy_cloud_nat = false`, `custom_vpc_configuration` set — full apply + verify + destroy
- [x] Full destroy + re-apply + scan test cycle for BYO VPC config (idempotency)

**DSPM Toggle (In-Place Modification)**
- [x] `enable_dspm = true` → `false`: in-place modification removes DSPM resources, preserves base registration
- [x] Region removal: reduce 3 regions → 1 — subnets/NAT destroyed cleanly

### IAM & Security
- [x] IAM condition restricts Compute mutations to resources matching `cs-scanning-{id}` prefix only
- [x] WIF principal scoped to specific registration ID (session name = registration UUID)
- [x] Scanner SA created per host project with least-privilege roles
- [x] No public IP assigned to scanner VM (private-only, NAT for egress)

### Pending / Not Yet Verified
- [~] **Infrastructure Manager example** — testing was started and the example config, inputs, and setup script work as expected; full verification is blocked on the corresponding Terraform provider change (pending merge) and will be completed once that lands
