### PR TITLE
Fix Agentless Scanning custom vpc multi-project

### DIFF
--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -37,7 +37,8 @@ locals {
   # Custom VPC subnet IAM pairs: flatten config into project/region pairs.
   # Keyed off the single scanner infra project (see custom_vpc_project_id), not
   # var.host_project_id, so single-project no-cross (host_project_id == null) works.
-  custom_vpc_subnet_pairs = local.is_custom_vpc ? {
+  # Empty when custom_vpc_project_id is null.
+  custom_vpc_subnet_pairs = local.is_custom_vpc && local.custom_vpc_project_id != null ? {
     for region, subnet in var.custom_vpc_configuration.subnets :
     "${local.custom_vpc_project_id}/${region}" => { project = local.custom_vpc_project_id, region = region, subnetwork = subnet }
   } : {}
@@ -69,13 +70,10 @@ locals {
   # - Per-project (project scope only): ALL project_ids (each gets full infra)
   host_project_ids = var.host_project_id != null ? [var.host_project_id] : var.project_ids
 
-  # The single project that owns the scanner VPC/subnets, used by custom (BYO) VPC.
-  # Custom VPC requires exactly one infra project: cross => the host project;
-  # single-project no-cross => that one project. one() errors if there is >1 infra
-  # project (multi-project no-cross), which custom VPC can't support — a cryptic
-  # last-line backstop. The root module's friendly precondition on
-  # crowdstrike_cloud_google_registration.main catches this first in normal use.
-  custom_vpc_project_id = one(local.host_project_ids)
+  # Single infra project that owns the scanner VPC/subnets (custom BYO VPC only).
+  # Custom VPC requires exactly one infra project. Resolves to null when custom VPC
+  # is unused or the infra project isn't exactly one, so local eval never crashes.
+  custom_vpc_project_id = local.is_custom_vpc && length(local.host_project_ids) == 1 ? local.host_project_ids[0] : null
 
   # Projects that need scanning permissions only (cross mode targets for project registrations)
   # - Org/Folder: empty (org-level role handles all targets automatically)


### PR DESCRIPTION
## Summary
Fix multi-project no-cross registrations failing during plan when enable_dspm = true.
custom_vpc_project_id used one(local.host_project_ids), which errors on lists with more than one element. In multi-project no-cross mode (host_project_id unset, multiple project_ids), host_project_ids falls back to all project_ids, so one() crashed during local evaluation, even when custom VPC wasn't in use, and before any precondition could produce a friendly message.
Also guarded custom_vpc_subnet_pairs on custom_vpc_project_id != null so invalid custom-VPC configs (e.g. multi-project + custom VPC) produce only the friendly precondition error instead of a null-interpolation crash at the map key.    

## Test plan
- Multi-project no-cross (the bug): project_ids = [p1, p2], no host_project_id, enable_dspm = true, no custom VPC → terraform plan succeeds (previously errored at one())
- Single-project no-cross + custom VPC: one project_id, no host_project_id, custom VPC set → plan succeeds, subnet IAM targets that project
- Cross mode + custom VPC: host_project_id set, multiple project_ids, custom VPC → plan succeeds, infra on the host project