### PR TITLE
bump crowdstrike provider floor to >= 0.0.78 for DSPM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ module "crowdstrike_gcp_registration" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | >= 0.0.55 |
+| <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | >= 0.0.78 |
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.22 |
 ## Resources
 

--- a/examples/generic-registration/versions.tf
+++ b/examples/generic-registration/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     crowdstrike = {
       source  = "crowdstrike/crowdstrike"
-      version = ">= 0.0.55"
+      version = ">= 0.0.78"
     }
   }
 }

--- a/examples/infrastructure-manager/versions.tf
+++ b/examples/infrastructure-manager/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     crowdstrike = {
       source  = "crowdstrike/crowdstrike"
-      version = ">= 0.0.55"
+      version = ">= 0.0.78"
     }
   }
 }

--- a/examples/native-terraform/versions.tf
+++ b/examples/native-terraform/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     crowdstrike = {
       source  = "crowdstrike/crowdstrike"
-      version = ">= 0.0.55"
+      version = ">= 0.0.78"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     crowdstrike = {
       source  = "crowdstrike/crowdstrike"
-      version = ">= 0.0.55"
+      version = ">= 0.0.78"
     }
   }
 }


### PR DESCRIPTION
## Summary
Raises the minimum crowdstrike/crowdstrike provider version from >= 0.0.55 to >= 0.0.78 across all configurations. DSPM support requires provider 0.0.78, so this floor ensures consumers resolve a provider version that includes the DSPM resources/fields.

Updated in all four versions.tf files:
- Root module (versions.tf)
- examples/generic-registration
- examples/infrastructure-manager
- examples/native-terraform 

This is a version-floor change only — no resource configuration, module logic, or documentation is affected.