### PR TITLE
CSPG-97337-agentless-scanning-vulnerability-feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ module "crowdstrike_gcp_registration" {
 | <a name="input_deployment_method"></a> [deployment\_method](#input\_deployment\_method) | Deployment method for the CrowdStrike GCP registration | `string` | `"terraform-native"` | no |
 | <a name="input_enable_dspm"></a> [enable\_dspm](#input\_enable\_dspm) | Enable DSPM agentless scanning infrastructure | `bool` | `false` | no |
 | <a name="input_enable_realtime_visibility"></a> [enable\_realtime\_visibility](#input\_enable\_realtime\_visibility) | Enable Real Time Visibility and Detection (RTV&D) features via log ingestion | `bool` | `false` | no |
+| <a name="input_enable_vulnerability_scanning"></a> [enable\_vulnerability\_scanning](#input\_enable\_vulnerability\_scanning) | Enable agentless vulnerability scanning infrastructure | `bool` | `false` | no |
 | <a name="input_excluded_project_patterns"></a> [excluded\_project\_patterns](#input\_excluded\_project\_patterns) | List of shell-style patterns to exclude specific projects from CSPM registration. Supports wildcards (* and ?). Projects matching these patterns will be excluded from asset inventory and log ingestion. Examples: 'sys-*', 'dev-?'. | `list(string)` | `[]` | no |
 | <a name="input_falcon_client_id"></a> [falcon\_client\_id](#input\_falcon\_client\_id) | Falcon API client ID. | `string` | `null` | no |
 | <a name="input_falcon_client_secret"></a> [falcon\_client\_secret](#input\_falcon\_client\_secret) | Falcon API client secret. | `string` | `null` | no |

--- a/examples/generic-registration/README.md
+++ b/examples/generic-registration/README.md
@@ -4,22 +4,23 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.50 |
+| <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.55 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | 0.0.55  |
+| <a name="provider_crowdstrike"></a> [crowdstrike](#provider\_crowdstrike) | >= 0.0.55 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.22 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_agentless_scanning"></a> [agentless\_scanning](#module\_agentless\_scanning) | ../../modules/agentless-scanning/ | n/a |
 | <a name="module_asset-inventory"></a> [asset-inventory](#module\_asset-inventory) | ../../modules/asset-inventory/ | n/a |
 | <a name="module_log-ingestion"></a> [log-ingestion](#module\_log-ingestion) | ../../modules/log-ingestion/ | n/a |
-| <a name="module_project-discovery"></a> [project-discovery](#module\_project-discovery) | ../../modules/project-discovery/ | n/a |
 | <a name="module_workload-identity"></a> [workload-identity](#module\_workload-identity) | ../../modules/workload-identity/ | n/a |
 
 ## Resources
@@ -27,18 +28,26 @@
 | Name | Type |
 |------|------|
 | [crowdstrike_cloud_google_registration.main](https://registry.terraform.io/providers/crowdstrike/crowdstrike/latest/docs/resources/cloud_google_registration) | resource |
-| [crowdstrike_cloud_google_registration_logging_settings.main](https://registry.terraform.io/providers/crowdstrike/crowdstrike/latest/docs/resources/cloud_google_registration_logging_settings) | resource |
+| [crowdstrike_cloud_google_registration_settings.main](https://registry.terraform.io/providers/crowdstrike/crowdstrike/latest/docs/resources/cloud_google_registration_settings) | resource |
+| [google_project.wif_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_agentless_scanning_role_arn"></a> [agentless\_scanning\_role\_arn](#input\_agentless\_scanning\_role\_arn) | AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable\_dspm is true. | `string` | `null` | no |
+| <a name="input_agentless_scanning_settings"></a> [agentless\_scanning\_settings](#input\_agentless\_scanning\_settings) | Configuration settings for agentless scanning infrastructure. Controls scanning scope, VPC, and network settings. | <pre>object({<br/>    host_project_id  = optional(string)<br/>    org_id           = optional(string)<br/>    regions          = optional(set(string), [])<br/>    deploy_cloud_nat = optional(bool, true)<br/>    custom_vpc_configuration = optional(object({<br/>      vpc_name = string<br/>      subnets  = map(string)<br/>    }))<br/>  })</pre> | `{}` | no |
+| <a name="input_deployment_method"></a> [deployment\_method](#input\_deployment\_method) | Deployment method for the CrowdStrike GCP registration | `string` | `"terraform-native"` | no |
+| <a name="input_enable_dspm"></a> [enable\_dspm](#input\_enable\_dspm) | Enable DSPM agentless scanning infrastructure | `bool` | `false` | no |
 | <a name="input_enable_realtime_visibility"></a> [enable\_realtime\_visibility](#input\_enable\_realtime\_visibility) | Enable Real Time Visibility & Detection features (requires log ingestion setup) | `bool` | `false` | no |
+| <a name="input_enable_vulnerability_scanning"></a> [enable\_vulnerability\_scanning](#input\_enable\_vulnerability\_scanning) | Enable agentless vulnerability scanning for GCP Compute Engine VMs | `bool` | `false` | no |
+| <a name="input_excluded_project_patterns"></a> [excluded\_project\_patterns](#input\_excluded\_project\_patterns) | List of shell-style patterns to exclude specific projects from CSPM registration. Supports wildcards (* and ?). Projects matching these patterns will be excluded from asset inventory and log ingestion. Examples: 'sys-*', 'dev-?'. | `list(string)` | `[]` | no |
 | <a name="input_falcon_client_id"></a> [falcon\_client\_id](#input\_falcon\_client\_id) | Falcon API client ID. | `string` | n/a | yes |
 | <a name="input_falcon_client_secret"></a> [falcon\_client\_secret](#input\_falcon\_client\_secret) | Falcon API client secret. | `string` | n/a | yes |
 | <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folders being registered | `list(string)` | `[]` | no |
 | <a name="input_infra_project_id"></a> [infra\_project\_id](#input\_infra\_project\_id) | GCP Project ID where CrowdStrike infrastructure will be created (WIF pools, Pub/Sub topics, etc.) | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to all created resources | `map(string)` | `{}` | no |
+| <a name="input_log_ingestion_settings"></a> [log\_ingestion\_settings](#input\_log\_ingestion\_settings) | Configuration settings for log ingestion. Controls Pub/Sub topic and subscription settings, audit log types, schema validation, and allows using existing resources. | <pre>object({<br/>    message_retention_duration       = optional(string, "604800s")<br/>    ack_deadline_seconds             = optional(number, 600)<br/>    topic_message_retention_duration = optional(string, "604800s")<br/>    audit_log_types                  = optional(list(string), ["activity", "system_event", "policy"])<br/>    topic_storage_regions            = optional(list(string), [])<br/>    enable_schema_validation         = optional(bool, false)<br/>    schema_type                      = optional(string, "AVRO")<br/>    schema_definition                = optional(string)<br/>    existing_topic_name              = optional(string)<br/>    existing_subscription_name       = optional(string)<br/>    exclusion_filters                = optional(list(string), [])<br/>  })</pre> | `{}` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | GCP Organization ID for organization-level registration | `string` | `null` | no |
 | <a name="input_project_ids"></a> [project\_ids](#input\_project\_ids) | List of GCP Project IDs to register with CrowdStrike CSPM | `list(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | GCP region for resource deployment | `string` | `"us-central1"` | no |
@@ -55,7 +64,6 @@
 |------|-------------|
 | <a name="output_aws_integration"></a> [aws\_integration](#output\_aws\_integration) | AWS integration details for CrowdStrike identity federation |
 | <a name="output_deployment_timestamp"></a> [deployment\_timestamp](#output\_deployment\_timestamp) | Timestamp when the deployment was completed |
-| <a name="output_discovered_projects"></a> [discovered\_projects](#output\_discovered\_projects) | Detailed information about discovered and registered projects |
 | <a name="output_infra_project_id"></a> [infra\_project\_id](#output\_infra\_project\_id) | The GCP Project ID where CrowdStrike infrastructure was created |
 | <a name="output_log_ingestion_enabled"></a> [log\_ingestion\_enabled](#output\_log\_ingestion\_enabled) | Whether Real Time Visibility & Detection log ingestion is enabled |
 | <a name="output_log_sink_names"></a> [log\_sink\_names](#output\_log\_sink\_names) | Names of the created log sinks (if RTV&D enabled) |

--- a/examples/generic-registration/main.tf
+++ b/examples/generic-registration/main.tf
@@ -126,7 +126,7 @@ module "log-ingestion" {
 }
 
 module "agentless_scanning" {
-  count  = var.enable_dspm ? 1 : 0
+  count  = (var.enable_dspm || var.enable_vulnerability_scanning) ? 1 : 0
   source = "../../modules/agentless-scanning/"
 
   registration_type = var.registration_type
@@ -143,6 +143,9 @@ module "agentless_scanning" {
   wif_project_number          = data.google_project.wif_project.number
   wif_pool_id                 = module.workload-identity.wif_pool_id
   agentless_scanning_role_arn = var.agentless_scanning_role_arn
+
+  enable_dspm                   = var.enable_dspm
+  enable_vulnerability_scanning = var.enable_vulnerability_scanning
 
   falcon_client_id     = var.falcon_client_id
   falcon_client_secret = var.falcon_client_secret
@@ -166,7 +169,7 @@ resource "crowdstrike_cloud_google_registration_settings" "main" {
   log_ingestion_subscription_name = try(module.log-ingestion[0].subscription_name, null)
   log_ingestion_sink_name         = try(values(module.log-ingestion[0].log_sink_names)[0], null)
 
-  agentless_scanning_settings = var.enable_dspm ? {
+  agentless_scanning_settings = (var.enable_dspm || var.enable_vulnerability_scanning) ? {
     wif_principal              = module.agentless_scanning[0].agentless_wif_principal
     deployment_version         = module.agentless_scanning[0].deployment_version
     regions                    = var.agentless_scanning_settings.regions

--- a/examples/generic-registration/variables.tf
+++ b/examples/generic-registration/variables.tf
@@ -144,6 +144,12 @@ variable "enable_dspm" {
   default     = false
 }
 
+variable "enable_vulnerability_scanning" {
+  type        = bool
+  description = "Enable agentless vulnerability scanning for GCP Compute Engine VMs"
+  default     = false
+}
+
 variable "agentless_scanning_role_arn" {
   type        = string
   description = "AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable_dspm is true."

--- a/examples/infrastructure-manager/README.md
+++ b/examples/infrastructure-manager/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.50 |
+| <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.55 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.45.2 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.22 |
 
 ## Modules
 
@@ -29,21 +29,28 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_agentless_scanning_role_arn"></a> [agentless\_scanning\_role\_arn](#input\_agentless\_scanning\_role\_arn) | AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable\_dspm is true. | `string` | `null` | no |
+| <a name="input_agentless_scanning_settings"></a> [agentless\_scanning\_settings](#input\_agentless\_scanning\_settings) | Configuration settings for agentless scanning infrastructure. Controls scanning scope, VPC, and network settings. | <pre>object({<br/>    host_project_id  = optional(string)<br/>    org_id           = optional(string)<br/>    regions          = optional(set(string), [])<br/>    deploy_cloud_nat = optional(bool, true)<br/>    custom_vpc_configuration = optional(object({<br/>      vpc_name = string<br/>      subnets  = map(string)<br/>    }))<br/>  })</pre> | `{}` | no |
 | <a name="input_deployment_method"></a> [deployment\_method](#input\_deployment\_method) | Deployment method for the CrowdStrike GCP registration | `string` | `"terraform-native"` | no |
+| <a name="input_enable_dspm"></a> [enable\_dspm](#input\_enable\_dspm) | Enable DSPM agentless scanning infrastructure | `bool` | `false` | no |
 | <a name="input_enable_realtime_visibility"></a> [enable\_realtime\_visibility](#input\_enable\_realtime\_visibility) | Enable Real Time Visibility & Detection features (requires log ingestion setup) | `bool` | `false` | no |
+| <a name="input_enable_vulnerability_scanning"></a> [enable\_vulnerability\_scanning](#input\_enable\_vulnerability\_scanning) | Enable agentless vulnerability scanning for GCP Compute Engine VMs | `bool` | `false` | no |
+| <a name="input_excluded_project_patterns"></a> [excluded\_project\_patterns](#input\_excluded\_project\_patterns) | List of shell-style patterns to exclude specific projects from CSPM registration. Supports wildcards (* and ?). Projects matching these patterns will be excluded from asset inventory and log ingestion. Examples: 'sys-*', 'dev-?'. | `list(string)` | `[]` | no |
 | <a name="input_falcon_client_id"></a> [falcon\_client\_id](#input\_falcon\_client\_id) | Falcon API client ID. | `string` | n/a | yes |
 | <a name="input_falcon_client_secret"></a> [falcon\_client\_secret](#input\_falcon\_client\_secret) | Falcon API client secret. If not provided, will be retrieved from Secret Manager. | `string` | `null` | no |
 | <a name="input_falcon_client_secret_name"></a> [falcon\_client\_secret\_name](#input\_falcon\_client\_secret\_name) | Name of the Secret Manager secret containing the Falcon API client secret | `string` | `"crowdstrike-falcon-client-secret"` | no |
+| <a name="input_falcon_cloud"></a> [falcon\_cloud](#input\_falcon\_cloud) | CrowdStrike cloud environment. Set to 'us-gov-1' or 'us-gov-2' for government cloud deployments. Defaults to commercial cloud when null. | `string` | `null` | no |
 | <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folders being registered | `list(string)` | `[]` | no |
 | <a name="input_infra_project_id"></a> [infra\_project\_id](#input\_infra\_project\_id) | GCP Project ID where CrowdStrike infrastructure will be created (WIF pools, Pub/Sub topics, etc.) | `string` | n/a | yes |
+| <a name="input_infrastructure_manager_region"></a> [infrastructure\_manager\_region](#input\_infrastructure\_manager\_region) | The Google Cloud region for Infrastructure Manager. Required when deployment\_method is infrastructure-manager | `string` | `"us-central1"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to all created resources | `map(string)` | `{}` | no |
 | <a name="input_log_ingestion_settings"></a> [log\_ingestion\_settings](#input\_log\_ingestion\_settings) | Configuration settings for log ingestion. Controls Pub/Sub topic and subscription settings, audit log types, schema validation, and allows using existing resources. | <pre>object({<br/>    message_retention_duration       = optional(string, "604800s")<br/>    ack_deadline_seconds             = optional(number, 600)<br/>    topic_message_retention_duration = optional(string, "604800s")<br/>    audit_log_types                  = optional(list(string), ["activity", "system_event", "policy"])<br/>    topic_storage_regions            = optional(list(string), [])<br/>    enable_schema_validation         = optional(bool, false)<br/>    schema_type                      = optional(string, "AVRO")<br/>    schema_definition                = optional(string)<br/>    existing_topic_name              = optional(string)<br/>    existing_subscription_name       = optional(string)<br/>    exclusion_filters                = optional(list(string), [])<br/>  })</pre> | `{}` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | GCP Organization ID for organization-level registration | `string` | `null` | no |
 | <a name="input_project_ids"></a> [project\_ids](#input\_project\_ids) | List of GCP Project IDs to register with CrowdStrike CSPM | `list(string)` | `[]` | no |
 | <a name="input_registration_name"></a> [registration\_name](#input\_registration\_name) | Name for the CrowdStrike GCP registration | `string` | n/a | yes |
 | <a name="input_registration_type"></a> [registration\_type](#input\_registration\_type) | Type of registration: organization, folder, or project | `string` | n/a | yes |
-| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix for resource names (helps with organization and identification) | `string` | `null` | no |
-| <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | Suffix for resource names (helps with organization and identification) | `string` | `null` | no |
+| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix to be added to all created resource names for identification | `string` | `null` | no |
+| <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | Suffix to be added to all created resource names for identification | `string` | `null` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | AWS IAM Role ARN for CrowdStrike identity federation | `string` | n/a | yes |
 | <a name="input_wif_project_id"></a> [wif\_project\_id](#input\_wif\_project\_id) | Google Cloud Project ID where the CrowdStrike workload identity federation pool resources are deployed. Defaults to infra\_project\_id if not specified | `string` | `null` | no |
 

--- a/examples/infrastructure-manager/main.tf
+++ b/examples/infrastructure-manager/main.tf
@@ -80,9 +80,10 @@ module "crowdstrike_gcp_registration" {
   excluded_project_patterns = var.excluded_project_patterns
 
   # Optional: Agentless scanning
-  enable_dspm                 = var.enable_dspm
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = local.falcon_client_secret
-  agentless_scanning_role_arn = var.agentless_scanning_role_arn
-  agentless_scanning_settings = var.agentless_scanning_settings
+  enable_dspm                   = var.enable_dspm
+  enable_vulnerability_scanning = var.enable_vulnerability_scanning
+  falcon_client_id              = var.falcon_client_id
+  falcon_client_secret          = local.falcon_client_secret
+  agentless_scanning_role_arn   = var.agentless_scanning_role_arn
+  agentless_scanning_settings   = var.agentless_scanning_settings
 }

--- a/examples/infrastructure-manager/variables.tf
+++ b/examples/infrastructure-manager/variables.tf
@@ -246,6 +246,12 @@ variable "enable_dspm" {
   default     = false
 }
 
+variable "enable_vulnerability_scanning" {
+  type        = bool
+  description = "Enable agentless vulnerability scanning for GCP Compute Engine VMs"
+  default     = false
+}
+
 variable "agentless_scanning_role_arn" {
   type        = string
   description = "AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable_dspm is true."

--- a/examples/native-terraform/README.md
+++ b/examples/native-terraform/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.50 |
+| <a name="requirement_crowdstrike"></a> [crowdstrike](#requirement\_crowdstrike) | >= 0.0.55 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.22 |
 
 ## Providers
@@ -25,10 +25,16 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_agentless_scanning_role_arn"></a> [agentless\_scanning\_role\_arn](#input\_agentless\_scanning\_role\_arn) | AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable\_dspm is true. | `string` | `null` | no |
+| <a name="input_agentless_scanning_settings"></a> [agentless\_scanning\_settings](#input\_agentless\_scanning\_settings) | Configuration settings for agentless scanning infrastructure. Controls scanning scope, VPC, and network settings. | <pre>object({<br/>    host_project_id  = optional(string)<br/>    org_id           = optional(string)<br/>    regions          = optional(set(string), [])<br/>    deploy_cloud_nat = optional(bool, true)<br/>    custom_vpc_configuration = optional(object({<br/>      vpc_name = string<br/>      subnets  = map(string)<br/>    }))<br/>  })</pre> | `{}` | no |
 | <a name="input_deployment_method"></a> [deployment\_method](#input\_deployment\_method) | Deployment method for the CrowdStrike GCP registration | `string` | `"terraform-native"` | no |
+| <a name="input_enable_dspm"></a> [enable\_dspm](#input\_enable\_dspm) | Enable DSPM agentless scanning infrastructure | `bool` | `false` | no |
 | <a name="input_enable_realtime_visibility"></a> [enable\_realtime\_visibility](#input\_enable\_realtime\_visibility) | Enable Real Time Visibility & Detection features (requires log ingestion setup) | `bool` | `false` | no |
+| <a name="input_enable_vulnerability_scanning"></a> [enable\_vulnerability\_scanning](#input\_enable\_vulnerability\_scanning) | Enable agentless vulnerability scanning for GCP Compute Engine VMs | `bool` | `false` | no |
+| <a name="input_excluded_project_patterns"></a> [excluded\_project\_patterns](#input\_excluded\_project\_patterns) | List of shell-style patterns to exclude specific projects from CSPM registration. Supports wildcards (* and ?). Projects matching these patterns will be excluded from asset inventory and log ingestion. Examples: 'sys-*', 'dev-?'. | `list(string)` | `[]` | no |
 | <a name="input_falcon_client_id"></a> [falcon\_client\_id](#input\_falcon\_client\_id) | Falcon API client ID. | `string` | n/a | yes |
 | <a name="input_falcon_client_secret"></a> [falcon\_client\_secret](#input\_falcon\_client\_secret) | Falcon API client secret. | `string` | n/a | yes |
+| <a name="input_falcon_cloud"></a> [falcon\_cloud](#input\_falcon\_cloud) | CrowdStrike cloud environment. Set to 'us-gov-1' or 'us-gov-2' for government cloud deployments. Defaults to commercial cloud when null. | `string` | `null` | no |
 | <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folders being registered | `list(string)` | `[]` | no |
 | <a name="input_infra_project_id"></a> [infra\_project\_id](#input\_infra\_project\_id) | GCP Project ID where CrowdStrike infrastructure will be created (WIF pools, Pub/Sub topics, etc.) | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to all created resources | `map(string)` | `{}` | no |
@@ -37,8 +43,8 @@ No resources.
 | <a name="input_project_ids"></a> [project\_ids](#input\_project\_ids) | List of GCP Project IDs to register with CrowdStrike CSPM | `list(string)` | `[]` | no |
 | <a name="input_registration_name"></a> [registration\_name](#input\_registration\_name) | Name for the CrowdStrike GCP registration | `string` | n/a | yes |
 | <a name="input_registration_type"></a> [registration\_type](#input\_registration\_type) | Type of registration: organization, folder, or project | `string` | n/a | yes |
-| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix for resource names (helps with organization and identification) | `string` | `null` | no |
-| <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | Suffix for resource names (helps with organization and identification) | `string` | `null` | no |
+| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix to be added to all created resource names for identification | `string` | `null` | no |
+| <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | Suffix to be added to all created resource names for identification | `string` | `null` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | AWS IAM Role ARN for CrowdStrike identity federation | `string` | n/a | yes |
 | <a name="input_wif_project_id"></a> [wif\_project\_id](#input\_wif\_project\_id) | Google Cloud Project ID where the CrowdStrike workload identity federation pool resources are deployed. Defaults to infra\_project\_id if not specified | `string` | `null` | no |
 

--- a/examples/native-terraform/main.tf
+++ b/examples/native-terraform/main.tf
@@ -60,9 +60,10 @@ module "crowdstrike_gcp_registration" {
   excluded_project_patterns = var.excluded_project_patterns
 
   # Optional: Agentless scanning
-  enable_dspm                 = var.enable_dspm
-  falcon_client_id            = var.falcon_client_id
-  falcon_client_secret        = var.falcon_client_secret
-  agentless_scanning_role_arn = var.agentless_scanning_role_arn
-  agentless_scanning_settings = var.agentless_scanning_settings
+  enable_dspm                   = var.enable_dspm
+  enable_vulnerability_scanning = var.enable_vulnerability_scanning
+  falcon_client_id              = var.falcon_client_id
+  falcon_client_secret          = var.falcon_client_secret
+  agentless_scanning_role_arn   = var.agentless_scanning_role_arn
+  agentless_scanning_settings   = var.agentless_scanning_settings
 }

--- a/examples/native-terraform/variables.tf
+++ b/examples/native-terraform/variables.tf
@@ -228,6 +228,12 @@ variable "enable_dspm" {
   default     = false
 }
 
+variable "enable_vulnerability_scanning" {
+  type        = bool
+  description = "Enable agentless vulnerability scanning for GCP Compute Engine VMs"
+  default     = false
+}
+
 variable "agentless_scanning_role_arn" {
   type        = string
   description = "AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF. Required when enable_dspm is true."

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,11 @@ resource "crowdstrike_cloud_google_registration" "main" {
     enabled = var.enable_dspm
   }
 
+  # Enable vulnerability scanning if requested
+  vulnerability_scanning = {
+    enabled = var.enable_vulnerability_scanning
+  }
+
   # Project exclusion patterns
   excluded_project_patterns = var.excluded_project_patterns
 }
@@ -132,8 +137,12 @@ module "log-ingestion" {
 }
 
 module "agentless_scanning" {
-  count  = var.enable_dspm ? 1 : 0
+  count  = (var.enable_dspm || var.enable_vulnerability_scanning) ? 1 : 0
   source = "./modules/agentless-scanning/"
+
+  # Feature flags
+  enable_dspm                   = var.enable_dspm
+  enable_vulnerability_scanning = var.enable_vulnerability_scanning
 
   # Common vars from root
   registration_type = var.registration_type
@@ -173,7 +182,7 @@ resource "crowdstrike_cloud_google_registration_settings" "main" {
   log_ingestion_subscription_name = try(module.log-ingestion[0].subscription_name, null)
   log_ingestion_sink_name         = try(values(module.log-ingestion[0].log_sink_names)[0], null)
 
-  agentless_scanning_settings = var.enable_dspm ? {
+  agentless_scanning_settings = (var.enable_dspm || var.enable_vulnerability_scanning) ? {
     wif_principal              = module.agentless_scanning[0].agentless_wif_principal
     deployment_version         = module.agentless_scanning[0].deployment_version
     regions                    = var.agentless_scanning_settings.regions

--- a/modules/agentless-scanning/README.md
+++ b/modules/agentless-scanning/README.md
@@ -72,19 +72,29 @@ module "agentless_scanning" {
 | [google_compute_subnetwork_iam_member.wif_byo_subnet_network_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam_member) | resource |
 | [google_compute_subnetwork_iam_member.wif_subnet_network_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam_member) | resource |
 | [google_folder_iam_member.folder_scanner_gcs_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_folder_iam_member.folder_vulnerability_snapshot_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
 | [google_folder_iam_member.wif_viewer_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
 | [google_organization_iam_custom_role.folder_scanner_gcs_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_custom_role.folder_vulnerability_snapshot_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_custom_role.target_scanner_gcs_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_custom_role.target_vulnerability_snapshot_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_member.target_scanner_gcs_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_organization_iam_member.target_vulnerability_snapshot_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.wif_viewer_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_project_iam_custom_role.scanner_gcs_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.scanner_vulnerability_disk_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.target_scanner_gcs_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.target_vulnerability_snapshot_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.wif_compute_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.wif_vulnerability_target_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_member.scanner_gcs_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.scanner_vulnerability_disk_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.target_scanner_gcs_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.target_vulnerability_snapshot_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.wif_compute](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.wif_viewer_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.wif_viewer_roles_project_only](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.wif_vulnerability_target_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_project_service.serviceusage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_secret_manager_secret.falcon_credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
@@ -93,10 +103,15 @@ module "agentless_scanning" {
 | [google_service_account.scanner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_member.wif_can_use_scanner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [random_id.folder_org_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.folder_vulnerability_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.gcs_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.infra_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.target_gcs_role_org_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.target_gcs_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.target_vulnerability_role_org_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.target_vulnerability_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.vulnerability_disk_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_id.vulnerability_wif_host_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [terraform_data.agentless_validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [google_compute_subnetwork.byo_validation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 | [google_project_ancestry.host_project_scope_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project_ancestry) | data source |
@@ -107,6 +122,8 @@ module "agentless_scanning" {
 | <a name="input_agentless_scanning_role_arn"></a> [agentless\_scanning\_role\_arn](#input\_agentless\_scanning\_role\_arn) | AWS Role ARN used by CrowdStrike agentless scanning for authentication via WIF | `string` | n/a | yes |
 | <a name="input_custom_vpc_configuration"></a> [custom\_vpc\_configuration](#input\_custom\_vpc\_configuration) | Custom VPC configuration for the host project. When set, uses the provided VPC/subnets instead of creating a managed VPC. vpc\_name = VPC name, subnets = {region = subnet\_name}. | <pre>object({<br/>    vpc_name = string<br/>    subnets  = map(string)<br/>  })</pre> | `null` | no |
 | <a name="input_deploy_cloud_nat"></a> [deploy\_cloud\_nat](#input\_deploy\_cloud\_nat) | Deploy Cloud NAT for scanner VMs. true = private IPs + NAT, false = public IPs. | `bool` | `true` | no |
+| <a name="input_enable_dspm"></a> [enable\_dspm](#input\_enable\_dspm) | Enable DSPM (GCS scanning) permissions | `bool` | `false` | no |
+| <a name="input_enable_vulnerability_scanning"></a> [enable\_vulnerability\_scanning](#input\_enable\_vulnerability\_scanning) | Enable vulnerability scanning (disk snapshot/clone) permissions | `bool` | `false` | no |
 | <a name="input_falcon_client_id"></a> [falcon\_client\_id](#input\_falcon\_client\_id) | Falcon API client ID for scanner authentication | `string` | n/a | yes |
 | <a name="input_falcon_client_secret"></a> [falcon\_client\_secret](#input\_falcon\_client\_secret) | Falcon API client secret for scanner authentication | `string` | n/a | yes |
 | <a name="input_folder_ids"></a> [folder\_ids](#input\_folder\_ids) | List of Google Cloud folder IDs for folder-level registration | `list(string)` | `[]` | no |

--- a/modules/agentless-scanning/cross_targets.tf
+++ b/modules/agentless-scanning/cross_targets.tf
@@ -3,17 +3,17 @@
 # =============================================================================
 
 # =============================================================================
-# Org mode: single org-level custom role + binding
+# DSPM: Org mode - single org-level GCS custom role + binding
 # =============================================================================
 
 # Protects org-level target role against 44-day soft-delete collision
 resource "random_id" "target_gcs_role_org_suffix" {
-  count       = local.is_org_registration ? 1 : 0
+  count       = var.enable_dspm && local.is_org_registration ? 1 : 0
   byte_length = 4
 }
 
 resource "google_organization_iam_custom_role" "target_scanner_gcs_role" {
-  count = local.is_org_registration ? 1 : 0
+  count = var.enable_dspm && local.is_org_registration ? 1 : 0
 
   org_id      = var.organization_id
   role_id     = "${local.scanner_gcs_role.id_prefix}_${local.role_suffix}_${random_id.target_gcs_role_org_suffix[0].hex}"
@@ -24,7 +24,7 @@ resource "google_organization_iam_custom_role" "target_scanner_gcs_role" {
 }
 
 resource "google_organization_iam_member" "target_scanner_gcs_permissions" {
-  count = local.is_org_registration ? 1 : 0
+  count = var.enable_dspm && local.is_org_registration ? 1 : 0
 
   org_id = var.organization_id
   role   = google_organization_iam_custom_role.target_scanner_gcs_role[0].id
@@ -32,19 +32,17 @@ resource "google_organization_iam_member" "target_scanner_gcs_permissions" {
 }
 
 # =============================================================================
-# Multi-project (standalone cross) mode: per-target-project custom role + binding
+# DSPM: Multi-project (standalone cross) mode - per-target-project GCS role + binding
 # =============================================================================
-# Only used for project registrations in cross mode (cross_target_ids is empty
-# for org/folder, which bind a single org-level role instead).
 
 # Protects per-target-project role against 44-day soft-delete collision
 resource "random_id" "target_gcs_role_suffix" {
-  for_each    = toset(local.cross_target_ids)
+  for_each    = var.enable_dspm ? toset(local.cross_target_ids) : toset([])
   byte_length = 4
 }
 
 resource "google_project_iam_custom_role" "target_scanner_gcs_role" {
-  for_each = toset(local.cross_target_ids)
+  for_each = var.enable_dspm ? toset(local.cross_target_ids) : toset([])
 
   project     = each.value
   role_id     = "${local.scanner_gcs_role.id_prefix}_${local.role_suffix}_${random_id.target_gcs_role_suffix[each.value].hex}"
@@ -55,7 +53,7 @@ resource "google_project_iam_custom_role" "target_scanner_gcs_role" {
 }
 
 resource "google_project_iam_member" "target_scanner_gcs_permissions" {
-  for_each = toset(local.cross_target_ids)
+  for_each = var.enable_dspm ? toset(local.cross_target_ids) : toset([])
 
   project = each.value
   role    = google_project_iam_custom_role.target_scanner_gcs_role[each.value].id
@@ -63,18 +61,16 @@ resource "google_project_iam_member" "target_scanner_gcs_permissions" {
 }
 
 # =============================================================================
-# Folder + cross + org-level role: single org role bound at folder level
+# DSPM: Folder + cross + org-level role - single org role bound at folder level
 # =============================================================================
-# This avoids listing individual project IDs — the role is created at the org
-# and the binding at the folder inherits to all projects underneath.
 
 resource "random_id" "folder_org_role_suffix" {
-  count       = local.is_folder_registration ? 1 : 0
+  count       = var.enable_dspm && local.is_folder_registration ? 1 : 0
   byte_length = 4
 }
 
 resource "google_organization_iam_custom_role" "folder_scanner_gcs_role" {
-  count = local.is_folder_registration ? 1 : 0
+  count = var.enable_dspm && local.is_folder_registration ? 1 : 0
 
   org_id      = var.folder_org_id
   role_id     = "${local.scanner_gcs_role.id_prefix}_${local.role_suffix}_${random_id.folder_org_role_suffix[0].hex}"
@@ -85,9 +81,93 @@ resource "google_organization_iam_custom_role" "folder_scanner_gcs_role" {
 }
 
 resource "google_folder_iam_member" "folder_scanner_gcs_permissions" {
-  for_each = local.is_folder_registration ? toset(var.folder_ids) : toset([])
+  for_each = var.enable_dspm && local.is_folder_registration ? toset(var.folder_ids) : toset([])
 
   folder = "folders/${each.value}"
   role   = google_organization_iam_custom_role.folder_scanner_gcs_role[0].id
   member = "serviceAccount:${google_service_account.scanner_sa[var.host_project_id].email}"
+}
+
+# =============================================================================
+# Vulnerability Scanning: Org mode - org-level snapshot orchestrator role
+# =============================================================================
+
+resource "random_id" "target_vulnerability_role_org_suffix" {
+  count       = var.enable_vulnerability_scanning && local.is_org_registration ? 1 : 0
+  byte_length = 4
+}
+
+resource "google_organization_iam_custom_role" "target_vulnerability_snapshot_role" {
+  count = var.enable_vulnerability_scanning && local.is_org_registration ? 1 : 0
+
+  org_id      = var.organization_id
+  role_id     = "${local.vulnerability_wif_target_role.id_prefix}_${local.role_suffix}_${random_id.target_vulnerability_role_org_suffix[0].hex}"
+  title       = local.vulnerability_wif_target_role.title
+  description = local.vulnerability_wif_target_role.description
+
+  permissions = local.vulnerability_wif_target_role.permissions
+}
+
+resource "google_organization_iam_member" "target_vulnerability_snapshot_permissions" {
+  count = var.enable_vulnerability_scanning && local.is_org_registration ? 1 : 0
+
+  org_id = var.organization_id
+  role   = google_organization_iam_custom_role.target_vulnerability_snapshot_role[0].id
+  member = local.agentless_wif_principal
+}
+
+# =============================================================================
+# Vulnerability Scanning: Multi-project mode - per-target-project snapshot role
+# =============================================================================
+
+resource "random_id" "target_vulnerability_role_suffix" {
+  for_each    = var.enable_vulnerability_scanning ? toset(local.cross_target_ids) : toset([])
+  byte_length = 4
+}
+
+resource "google_project_iam_custom_role" "target_vulnerability_snapshot_role" {
+  for_each = var.enable_vulnerability_scanning ? toset(local.cross_target_ids) : toset([])
+
+  project     = each.value
+  role_id     = "${local.vulnerability_wif_target_role.id_prefix}_${local.role_suffix}_${random_id.target_vulnerability_role_suffix[each.value].hex}"
+  title       = local.vulnerability_wif_target_role.title
+  description = local.vulnerability_wif_target_role.description
+
+  permissions = local.vulnerability_wif_target_role.permissions
+}
+
+resource "google_project_iam_member" "target_vulnerability_snapshot_permissions" {
+  for_each = var.enable_vulnerability_scanning ? toset(local.cross_target_ids) : toset([])
+
+  project = each.value
+  role    = google_project_iam_custom_role.target_vulnerability_snapshot_role[each.value].id
+  member  = local.agentless_wif_principal
+}
+
+# =============================================================================
+# Vulnerability Scanning: Folder mode - org-level role bound at folder level
+# =============================================================================
+
+resource "random_id" "folder_vulnerability_role_suffix" {
+  count       = var.enable_vulnerability_scanning && local.is_folder_registration ? 1 : 0
+  byte_length = 4
+}
+
+resource "google_organization_iam_custom_role" "folder_vulnerability_snapshot_role" {
+  count = var.enable_vulnerability_scanning && local.is_folder_registration ? 1 : 0
+
+  org_id      = var.folder_org_id
+  role_id     = "${local.vulnerability_wif_target_role.id_prefix}_${local.role_suffix}_${random_id.folder_vulnerability_role_suffix[0].hex}"
+  title       = local.vulnerability_wif_target_role.title
+  description = local.vulnerability_wif_target_role.description
+
+  permissions = local.vulnerability_wif_target_role.permissions
+}
+
+resource "google_folder_iam_member" "folder_vulnerability_snapshot_permissions" {
+  for_each = var.enable_vulnerability_scanning && local.is_folder_registration ? toset(var.folder_ids) : toset([])
+
+  folder = "folders/${each.value}"
+  role   = google_organization_iam_custom_role.folder_vulnerability_snapshot_role[0].id
+  member = local.agentless_wif_principal
 }

--- a/modules/agentless-scanning/cross_targets.tf
+++ b/modules/agentless-scanning/cross_targets.tf
@@ -114,6 +114,16 @@ resource "google_organization_iam_member" "target_vulnerability_snapshot_permiss
   org_id = var.organization_id
   role   = google_organization_iam_custom_role.target_vulnerability_snapshot_role[0].id
   member = local.agentless_wif_principal
+
+  condition {
+    title       = "restrict-to-crowdstrike-scanning-snapshots"
+    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
+    expression = join(" || ", [
+      "(resource.type == \"compute.googleapis.com/Disk\")",
+      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
+    ])
+  }
 }
 
 # =============================================================================
@@ -142,6 +152,16 @@ resource "google_project_iam_member" "target_vulnerability_snapshot_permissions"
   project = each.value
   role    = google_project_iam_custom_role.target_vulnerability_snapshot_role[each.value].id
   member  = local.agentless_wif_principal
+
+  condition {
+    title       = "restrict-to-crowdstrike-scanning-snapshots"
+    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
+    expression = join(" || ", [
+      "(resource.type == \"compute.googleapis.com/Disk\")",
+      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
+    ])
+  }
 }
 
 # =============================================================================
@@ -170,4 +190,14 @@ resource "google_folder_iam_member" "folder_vulnerability_snapshot_permissions" 
   folder = "folders/${each.value}"
   role   = google_organization_iam_custom_role.folder_vulnerability_snapshot_role[0].id
   member = local.agentless_wif_principal
+
+  condition {
+    title       = "restrict-to-crowdstrike-scanning-snapshots"
+    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
+    expression = join(" || ", [
+      "(resource.type == \"compute.googleapis.com/Disk\")",
+      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
+    ])
+  }
 }

--- a/modules/agentless-scanning/cross_targets.tf
+++ b/modules/agentless-scanning/cross_targets.tf
@@ -116,13 +116,9 @@ resource "google_organization_iam_member" "target_vulnerability_snapshot_permiss
   member = local.agentless_wif_principal
 
   condition {
-    title       = "restrict-to-crowdstrike-scanning-snapshots"
-    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
-    expression = join(" || ", [
-      "(resource.type == \"compute.googleapis.com/Disk\")",
-      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
-      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
-    ])
+    title       = local.vulnerability_snapshot_condition.title
+    description = local.vulnerability_snapshot_condition.description
+    expression  = local.vulnerability_snapshot_condition.expression
   }
 }
 
@@ -154,13 +150,9 @@ resource "google_project_iam_member" "target_vulnerability_snapshot_permissions"
   member  = local.agentless_wif_principal
 
   condition {
-    title       = "restrict-to-crowdstrike-scanning-snapshots"
-    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
-    expression = join(" || ", [
-      "(resource.type == \"compute.googleapis.com/Disk\")",
-      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
-      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
-    ])
+    title       = local.vulnerability_snapshot_condition.title
+    description = local.vulnerability_snapshot_condition.description
+    expression  = local.vulnerability_snapshot_condition.expression
   }
 }
 
@@ -192,12 +184,8 @@ resource "google_folder_iam_member" "folder_vulnerability_snapshot_permissions" 
   member = local.agentless_wif_principal
 
   condition {
-    title       = "restrict-to-crowdstrike-scanning-snapshots"
-    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
-    expression = join(" || ", [
-      "(resource.type == \"compute.googleapis.com/Disk\")",
-      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
-      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
-    ])
+    title       = local.vulnerability_snapshot_condition.title
+    description = local.vulnerability_snapshot_condition.description
+    expression  = local.vulnerability_snapshot_condition.expression
   }
 }

--- a/modules/agentless-scanning/iam.tf
+++ b/modules/agentless-scanning/iam.tf
@@ -24,17 +24,17 @@ resource "google_service_account" "scanner_sa" {
 }
 
 # =============================================================================
-# GCS IAM - Scanner SA Custom Role (per host project)
+# GCS IAM - Scanner SA Custom Role (per host project) [DSPM only]
 # =============================================================================
 
 # Protects scanner_gcs_role against 44-day soft-delete collision
 resource "random_id" "gcs_role_suffix" {
-  for_each    = toset(local.host_project_ids)
+  for_each    = var.enable_dspm && local.is_project_registration ? toset(local.host_project_ids) : toset([])
   byte_length = 4
 }
 
 resource "google_project_iam_custom_role" "scanner_gcs_role" {
-  for_each = toset(local.host_project_ids)
+  for_each = var.enable_dspm && local.is_project_registration ? toset(local.host_project_ids) : toset([])
 
   project     = each.value
   role_id     = "${local.scanner_gcs_role.id_prefix}_${local.role_suffix}_${random_id.gcs_role_suffix[each.value].hex}"
@@ -47,10 +47,47 @@ resource "google_project_iam_custom_role" "scanner_gcs_role" {
 }
 
 resource "google_project_iam_member" "scanner_gcs_permissions" {
-  for_each = toset(local.host_project_ids)
+  for_each = var.enable_dspm && local.is_project_registration ? toset(local.host_project_ids) : toset([])
 
   project = each.value
   role    = google_project_iam_custom_role.scanner_gcs_role[each.value].id
+  member  = "serviceAccount:${google_service_account.scanner_sa[each.value].email}"
+}
+
+# =============================================================================
+# Vulnerability Scanning - Scanner SA Disk Role (per host project)
+# =============================================================================
+
+resource "random_id" "vulnerability_disk_role_suffix" {
+  for_each    = var.enable_vulnerability_scanning ? toset(local.host_project_ids) : toset([])
+  byte_length = 4
+}
+
+resource "google_project_iam_custom_role" "scanner_vulnerability_disk_role" {
+  for_each = var.enable_vulnerability_scanning ? toset(local.host_project_ids) : toset([])
+
+  project     = each.value
+  role_id     = "VulnScannerDisk_${local.role_suffix}_${random_id.vulnerability_disk_role_suffix[each.value].hex}"
+  title       = "Vulnerability Scanner Disk"
+  description = "Disk attach/detach/read permissions for vulnerability scanning"
+
+  permissions = [
+    "compute.instances.attachDisk",
+    "compute.instances.detachDisk",
+    "compute.instances.get",
+    "compute.disks.use",
+    "compute.disks.useReadOnly",
+    "compute.zoneOperations.get",
+  ]
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_project_iam_member" "scanner_vulnerability_disk_permissions" {
+  for_each = var.enable_vulnerability_scanning ? toset(local.host_project_ids) : toset([])
+
+  project = each.value
+  role    = google_project_iam_custom_role.scanner_vulnerability_disk_role[each.value].id
   member  = "serviceAccount:${google_service_account.scanner_sa[each.value].email}"
 }
 
@@ -110,6 +147,39 @@ resource "google_service_account_iam_member" "wif_can_use_scanner_sa" {
   service_account_id = google_service_account.scanner_sa[each.value].id
   role               = "roles/iam.serviceAccountUser"
   member             = local.agentless_wif_principal
+}
+
+# =============================================================================
+# WIF Principal - Vulnerability Scanning Target Role (project registrations)
+# =============================================================================
+# In project registration mode, the host project is also a scan target (has VMs).
+# Org/folder modes don't need this — their org/folder-level binding in
+# cross_targets.tf already covers the host project.
+
+resource "random_id" "vulnerability_wif_host_role_suffix" {
+  for_each    = var.enable_vulnerability_scanning && local.is_project_registration ? toset(local.host_project_ids) : toset([])
+  byte_length = 4
+}
+
+resource "google_project_iam_custom_role" "wif_vulnerability_target_role" {
+  for_each = var.enable_vulnerability_scanning && local.is_project_registration ? toset(local.host_project_ids) : toset([])
+
+  project     = each.value
+  role_id     = "${local.vulnerability_wif_target_role.id_prefix}_${local.role_suffix}_${random_id.vulnerability_wif_host_role_suffix[each.value].hex}"
+  title       = local.vulnerability_wif_target_role.title
+  description = local.vulnerability_wif_target_role.description
+
+  permissions = local.vulnerability_wif_target_role.permissions
+
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_project_iam_member" "wif_vulnerability_target_permissions" {
+  for_each = var.enable_vulnerability_scanning && local.is_project_registration ? toset(local.host_project_ids) : toset([])
+
+  project = each.value
+  role    = google_project_iam_custom_role.wif_vulnerability_target_role[each.value].id
+  member  = local.agentless_wif_principal
 }
 
 # =============================================================================

--- a/modules/agentless-scanning/iam.tf
+++ b/modules/agentless-scanning/iam.tf
@@ -192,13 +192,9 @@ resource "google_project_iam_member" "wif_vulnerability_target_permissions" {
   member  = local.agentless_wif_principal
 
   condition {
-    title       = "restrict-to-crowdstrike-scanning-snapshots"
-    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
-    expression = join(" || ", [
-      "(resource.type == \"compute.googleapis.com/Disk\")",
-      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
-      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
-    ])
+    title       = local.vulnerability_snapshot_condition.title
+    description = local.vulnerability_snapshot_condition.description
+    expression  = local.vulnerability_snapshot_condition.expression
   }
 }
 

--- a/modules/agentless-scanning/iam.tf
+++ b/modules/agentless-scanning/iam.tf
@@ -131,6 +131,7 @@ resource "google_project_iam_custom_role" "wif_compute_role" {
     "compute.instances.start",
     "compute.disks.create",
     "compute.disks.delete",
+    "compute.disks.setLabels",
     "compute.disks.use",
     "compute.images.useReadOnly",
     "compute.zoneOperations.get",

--- a/modules/agentless-scanning/iam.tf
+++ b/modules/agentless-scanning/iam.tf
@@ -2,6 +2,19 @@
 # IAM - Service Accounts, Custom Roles, Viewer Roles
 # =============================================================================
 
+locals {
+  # IAM condition for scanner resource bindings — restricts Instance/Disk operations to cs-scanning-* only.
+  scanner_resource_condition = {
+    title       = "restrict-to-crowdstrike-scanner-resources"
+    description = "Restrict operations to CrowdStrike agentless scanner resources (cs-scanning-*) only"
+    expression = join(" || ", [
+      "(resource.type == \"compute.googleapis.com/Instance\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type == \"compute.googleapis.com/Disk\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type != \"compute.googleapis.com/Instance\" && resource.type != \"compute.googleapis.com/Disk\")",
+    ])
+  }
+}
+
 # =============================================================================
 # Scanner Service Account (per host project)
 # =============================================================================
@@ -91,13 +104,9 @@ resource "google_project_iam_member" "scanner_vulnerability_disk_permissions" {
   member  = "serviceAccount:${google_service_account.scanner_sa[each.value].email}"
 
   condition {
-    title       = "restrict-to-crowdstrike-scanner-resources"
-    description = "Limit disk operations to CrowdStrike agentless scanner resources only"
-    expression = join(" || ", [
-      "(resource.type == \"compute.googleapis.com/Instance\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
-      "(resource.type == \"compute.googleapis.com/Disk\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
-      "(resource.type != \"compute.googleapis.com/Instance\" && resource.type != \"compute.googleapis.com/Disk\")",
-    ])
+    title       = local.scanner_resource_condition.title
+    description = local.scanner_resource_condition.description
+    expression  = local.scanner_resource_condition.expression
   }
 }
 
@@ -140,13 +149,9 @@ resource "google_project_iam_member" "wif_compute" {
   member  = local.agentless_wif_principal
 
   condition {
-    title       = "restrict-to-crowdstrike-scanner-resources"
-    description = "Limit mutations to CrowdStrike agentless scanner resources only"
-    expression = join(" || ", [
-      "(resource.type == \"compute.googleapis.com/Instance\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
-      "(resource.type == \"compute.googleapis.com/Disk\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
-      "(resource.type != \"compute.googleapis.com/Instance\" && resource.type != \"compute.googleapis.com/Disk\")",
-    ])
+    title       = local.scanner_resource_condition.title
+    description = local.scanner_resource_condition.description
+    expression  = local.scanner_resource_condition.expression
   }
 }
 

--- a/modules/agentless-scanning/iam.tf
+++ b/modules/agentless-scanning/iam.tf
@@ -89,6 +89,16 @@ resource "google_project_iam_member" "scanner_vulnerability_disk_permissions" {
   project = each.value
   role    = google_project_iam_custom_role.scanner_vulnerability_disk_role[each.value].id
   member  = "serviceAccount:${google_service_account.scanner_sa[each.value].email}"
+
+  condition {
+    title       = "restrict-to-crowdstrike-scanner-resources"
+    description = "Limit disk operations to CrowdStrike agentless scanner resources only"
+    expression = join(" || ", [
+      "(resource.type == \"compute.googleapis.com/Instance\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type == \"compute.googleapis.com/Disk\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type != \"compute.googleapis.com/Instance\" && resource.type != \"compute.googleapis.com/Disk\")",
+    ])
+  }
 }
 
 # =============================================================================
@@ -180,6 +190,16 @@ resource "google_project_iam_member" "wif_vulnerability_target_permissions" {
   project = each.value
   role    = google_project_iam_custom_role.wif_vulnerability_target_role[each.value].id
   member  = local.agentless_wif_principal
+
+  condition {
+    title       = "restrict-to-crowdstrike-scanning-snapshots"
+    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
+    expression = join(" || ", [
+      "(resource.type == \"compute.googleapis.com/Disk\")",
+      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
+    ])
+  }
 }
 
 # =============================================================================

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -45,6 +45,7 @@ locals {
 
   # Registration ID truncated and sanitized for resource naming constraints:
   # - Custom role_id: max 64 chars. Longest role "AgentlessComputeMgr" (19) + 2 separators + 8 hex = 29 overhead → 33-char reg_id fits (62 total)
+  #   Vuln roles use shorter id_prefixes: "VulnScannerDisk" (15), "VulnScanningOrch" (16) to stay within 64.
   # - SA account_id: max 30 chars. "csscan-" (7) + 8 hex + 13 (max prefix+suffix) = 28 → within limit
   # We use the tighter constraint (23) for resource names, and 33 for role IDs.
   role_suffix  = replace(substr(var.registration_id, 0, 33), "-", "_")
@@ -58,6 +59,27 @@ locals {
     permissions = [
       "storage.objects.get",
       "storage.objects.list",
+    ]
+  }
+
+  # Vulnerability scanning target role — reused across host project (iam.tf) and cross-target roles (cross_targets.tf).
+  vulnerability_wif_target_role = {
+    id_prefix   = "VulnScanningOrch"
+    title       = "Vulnerability Scanning Orchestrator"
+    description = "Snapshot and clone disk permissions for cross-project vulnerability scanning"
+    permissions = [
+      "compute.disks.createSnapshot",
+      "compute.snapshots.create",
+      "compute.snapshots.get",
+      "compute.snapshots.list",
+      "compute.snapshots.useReadOnly",
+      "compute.snapshots.delete",
+      "compute.instances.get",
+      "compute.instances.list",
+      "compute.disks.get",
+      "compute.disks.list",
+      "compute.zoneOperations.get",
+      "compute.globalOperations.get",
     ]
   }
 
@@ -140,6 +162,10 @@ locals {
 
 resource "terraform_data" "agentless_validation" {
   lifecycle {
+    precondition {
+      condition     = var.enable_dspm || var.enable_vulnerability_scanning
+      error_message = "At least one of enable_dspm or enable_vulnerability_scanning must be true."
+    }
     precondition {
       condition     = var.agentless_scanning_role_arn != null
       error_message = "agentless_scanning_role_arn is required when enable_dspm = true."

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -70,6 +70,7 @@ locals {
     permissions = [
       "compute.disks.createSnapshot",
       "compute.snapshots.create",
+      "compute.snapshots.setLabels",
       "compute.snapshots.useReadOnly",
       "compute.snapshots.delete",
     ]

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -63,6 +63,8 @@ locals {
   }
 
   # Vulnerability scanning target role — reused across host project (iam.tf) and cross-target roles (cross_targets.tf).
+  # Read-only permissions (get, list, zoneOperations.get, globalOperations.get) are omitted because
+  # roles/compute.viewer (bound to WIF principal at all scopes) already provides them.
   vulnerability_wif_target_role = {
     id_prefix   = "VulnScanningOrch"
     title       = "Vulnerability Scanning Orchestrator"
@@ -70,16 +72,8 @@ locals {
     permissions = [
       "compute.disks.createSnapshot",
       "compute.snapshots.create",
-      "compute.snapshots.get",
-      "compute.snapshots.list",
       "compute.snapshots.useReadOnly",
       "compute.snapshots.delete",
-      "compute.instances.get",
-      "compute.instances.list",
-      "compute.disks.get",
-      "compute.disks.list",
-      "compute.zoneOperations.get",
-      "compute.globalOperations.get",
     ]
   }
 

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -21,7 +21,7 @@
 # =============================================================================
 
 locals {
-  deployment_version = "1.0.0"
+  deployment_version = "1.1.0"
 
   # Mode detection
   is_org_registration     = var.registration_type == "organization"
@@ -75,6 +75,18 @@ locals {
       "compute.snapshots.useReadOnly",
       "compute.snapshots.delete",
     ]
+  }
+
+  # IAM condition for vulnerability scanning bindings — allows createSnapshot on any disk
+  # but restricts snapshot mutations (create, delete, useReadOnly) to cs-scanning-* resources.
+  vulnerability_snapshot_condition = {
+    title       = "restrict-to-crowdstrike-scanning-snapshots"
+    description = "Allow createSnapshot on any disk but restrict snapshot mutations to cs-scanning-* resources"
+    expression = join(" || ", [
+      "(resource.type == \"compute.googleapis.com/Disk\")",
+      "(resource.type == \"compute.googleapis.com/Snapshot\" && resource.name.extract(\"cs-scanning-{id}\") != \"\")",
+      "(resource.type != \"compute.googleapis.com/Disk\" && resource.type != \"compute.googleapis.com/Snapshot\")",
+    ])
   }
 
   # -------------------------------------------------------------------------

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -168,11 +168,11 @@ resource "terraform_data" "agentless_validation" {
     }
     precondition {
       condition     = var.agentless_scanning_role_arn != null
-      error_message = "agentless_scanning_role_arn is required when enable_dspm = true."
+      error_message = "agentless_scanning_role_arn is required when enable_dspm or enable_vulnerability_scanning is true."
     }
     precondition {
       condition     = var.falcon_client_id != null && var.falcon_client_secret != null
-      error_message = "falcon_client_id and falcon_client_secret are required when enable_dspm = true."
+      error_message = "falcon_client_id and falcon_client_secret are required when enable_dspm or enable_vulnerability_scanning is true."
     }
     precondition {
       condition     = var.registration_type == "project" || var.host_project_id != null

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -62,9 +62,7 @@ locals {
     ]
   }
 
-  # Vulnerability scanning target role — reused across host project (iam.tf) and cross-target roles (cross_targets.tf).
-  # Read-only permissions (get, list, zoneOperations.get, globalOperations.get) are omitted because
-  # roles/compute.viewer (bound to WIF principal at all scopes) already provides them.
+  # Vulnerability scanning infra role — reused across host project and cross-target roles at project/folder/org scope.
   vulnerability_wif_target_role = {
     id_prefix   = "VulnScanningOrch"
     title       = "Vulnerability Scanning Orchestrator"

--- a/modules/agentless-scanning/variables.tf
+++ b/modules/agentless-scanning/variables.tf
@@ -3,6 +3,22 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
+# Feature Flags
+# -----------------------------------------------------------------------------
+
+variable "enable_dspm" {
+  type        = bool
+  description = "Enable DSPM (GCS scanning) permissions"
+  default     = false
+}
+
+variable "enable_vulnerability_scanning" {
+  type        = bool
+  description = "Enable vulnerability scanning (disk snapshot/clone) permissions"
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
 # Common (passed from root module)
 # -----------------------------------------------------------------------------
 

--- a/scripts/service-account-setup.sh
+++ b/scripts/service-account-setup.sh
@@ -22,7 +22,8 @@ usage() {
     echo "  --wif-project-id      GCP project ID for Workload Identity Federation (default: same as infra-project-id)"
     echo "  --enable-rtvd         Enable Real Time Visibility & Detection (default: false)"
     echo "  --enable-dspm         Enable DSPM agentless scanning (default: false)"
-    echo "  --agentless-org-id    Organization ID for agentless scanning (required for folder registration with --enable-dspm)"
+    echo "  --enable-vulnerability-scanning  Enable agentless vulnerability scanning (default: false)"
+    echo "  --agentless-org-id    Organization ID for agentless scanning (required for folder registration with agentless features)"
     echo "  --location            Infrastructure Manager location (default: us-central1)"
     echo "  --help                Show this help message"
     echo ""
@@ -42,6 +43,7 @@ REGISTRATION_TYPE=""
 PROJECT_ID=""
 ENABLE_RTVD=false
 ENABLE_DSPM=false
+ENABLE_VULNERABILITY_SCANNING=false
 AGENTLESS_ORG_ID=""
 ORGANIZATION_ID=""
 FOLDER_IDS=""
@@ -67,6 +69,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --enable-dspm)
             ENABLE_DSPM=true
+            shift
+            ;;
+        --enable-vulnerability-scanning)
+            ENABLE_VULNERABILITY_SCANNING=true
             shift
             ;;
         --agentless-org-id)
@@ -253,8 +259,8 @@ if [[ "$ENABLE_RTVD" == true ]]; then
     fi
 fi
 
-# Add DSPM project roles if enabled
-if [[ "$ENABLE_DSPM" == true ]]; then
+# Add agentless scanning project roles if enabled
+if [[ "$ENABLE_DSPM" == true || "$ENABLE_VULNERABILITY_SCANNING" == true ]]; then
     PROJECT_ROLES+=(
         "roles/compute.networkAdmin"
         "roles/iam.serviceAccountAdmin"
@@ -262,7 +268,7 @@ if [[ "$ENABLE_DSPM" == true ]]; then
         "roles/secretmanager.admin"
     )
 
-    # DSPM needs projectIamAdmin for IAM bindings on infra project
+    # Agentless needs projectIamAdmin for IAM bindings on infra project
     if [[ "$REGISTRATION_TYPE" == "project" ]]; then
         PROJECT_ROLES+=(
             "roles/resourcemanager.projectIamAdmin"
@@ -304,13 +310,13 @@ if [[ "$REGISTRATION_TYPE" == "folder" ]]; then
         )
     fi
 
-    # Add DSPM folder roles (for cross-project IAM bindings on target projects)
-    if [[ "$ENABLE_DSPM" == true ]]; then
+    # Add agentless scanning folder roles (for cross-project IAM bindings on target projects)
+    if [[ "$ENABLE_DSPM" == true || "$ENABLE_VULNERABILITY_SCANNING" == true ]]; then
         FOLDER_ROLES+=(
             "roles/resourcemanager.projectIamAdmin"
         )
 
-        # Folder+DSPM needs org-level role for custom role creation
+        # Folder+agentless needs org-level role for custom role creation
         if [[ -n "$AGENTLESS_ORG_ID" ]]; then
             echo "  Binding roles/iam.organizationRoleAdmin to organization $AGENTLESS_ORG_ID..."
             gcloud organizations add-iam-policy-binding $AGENTLESS_ORG_ID \
@@ -354,8 +360,8 @@ if [[ "$REGISTRATION_TYPE" == "organization" ]]; then
         )
     fi
 
-    # Add DSPM org roles (for org-level custom role creation)
-    if [[ "$ENABLE_DSPM" == true ]]; then
+    # Add agentless scanning org roles (for org-level custom role creation)
+    if [[ "$ENABLE_DSPM" == true || "$ENABLE_VULNERABILITY_SCANNING" == true ]]; then
         ORG_ROLES+=(
             "roles/iam.organizationRoleAdmin"
             "roles/resourcemanager.projectIamAdmin"

--- a/variables.tf
+++ b/variables.tf
@@ -174,6 +174,12 @@ variable "enable_dspm" {
   default     = false
 }
 
+variable "enable_vulnerability_scanning" {
+  type        = bool
+  description = "Enable agentless vulnerability scanning infrastructure"
+  default     = false
+}
+
 variable "falcon_client_id" {
   type        = string
   description = "Falcon API client ID."


### PR DESCRIPTION
## Summary                                                                                                                                                                                                   
                                                     
  Adds `enable_vulnerability_scanning` variable to the Terraform GCP registration module, enabling agentless vulnerability scanning for GCP Compute Engine VMs. Users can now enable DSPM, vulnerability       
  scanning, or both independently. Shared infrastructure (SA, VPC, WIF compute role, viewer roles, secrets) is created when either feature is enabled; DSPM-specific resources (GCS roles) are conditional on
  `enable_dspm`; vuln-specific resources (disk mounter, snapshot orchestrator) are conditional on `enable_vulnerability_scanning`.                                                                             
                                                     
  Closes CSPG-97337                                                                                                                                                                                            
   
  ## Changes                                                                                                                                                                                                   
                                                     
  - **Root `variables.tf`**: Added `enable_vulnerability_scanning` variable (default: `false`)                                                                                                                 
  - **Root `main.tf`**: Agentless module count gated on `enable_dspm || enable_vulnerability_scanning`; both flags passed through; registration resource updated with `vulnerability_scanning` block
  - **`modules/agentless-scanning/variables.tf`**: Added `enable_dspm` and `enable_vulnerability_scanning` variables                                                                                           
  - **`modules/agentless-scanning/main.tf`**: Added vuln permission locals (`vuln_scanner_disk_mounter_permissions`, `vuln_wif_target_permissions`)                                                            
  - **`modules/agentless-scanning/iam.tf`**: GCS role conditional on `enable_dspm`; added `VulnScannerDisk` custom role + binding conditional on `enable_vulnerability_scanning`                               
  - **`modules/agentless-scanning/cross_targets.tf`**: GCS cross-target roles conditional on `enable_dspm`; added `VulnScanningOrch` custom role + binding at org/folder/project scope conditional on          
  `enable_vulnerability_scanning`                                                                                                                                                                              
                                                                                                                                                                                                               
  ## IAM Roles Created                                                                                                                                                                                         
                                                                                                                                                                                                               
  | Role | Principal | Scope | Condition |
  |------|-----------|-------|-----------|                                                                                                                                                                     
  | `AgentlessComputeMgr` | WIF principal | Host project | Either feature enabled |                                                                                                                            
  | `DSPMScannerGCSRead` | Scanner SA | Host project (or org-level for folder mode) | `enable_dspm = true` |                                                                                                   
  | `VulnScannerDisk` | Scanner SA | Host project | `enable_vulnerability_scanning = true` |                                                                                                                   
  | `VulnScanningOrch` | WIF principal | Target projects (or org-level for folder mode) | `enable_vulnerability_scanning = true` |                                                                             
            

## IAM Condition Validation                                                                                                                                                                                                           
                                                     
  Tested IAM conditions on `mav-integration-project-2` by authenticating as the actual WIF principal (`CS-Integ-AgentlessScanningConnector-Dev`) via AWS STS → GCP Workload Identity Federation.                                        
   
  <details>                                                                                                                                                                                                                             
  <summary>Test Results (11/11 passed)</summary>     
                                                                                                                                                                                                                                        
  | # | Principal | Operation | Resource Name | Expected | Result | Permission Blocked |                                                                                                                                                
  |---|-----------|-----------|--------------|----------|--------|-------------------|                                                                                                                                                  
  | 1 | WIF | Create snapshot from customer disk | `cs-scanning-test-snapshot` | PASS | **PASS** | — |                                                                                                                                  
  | 2 | WIF | Create snapshot from customer disk | `unauthorized-snapshot` | DENY | **DENY** | `compute.snapshots.create` |                                                                                                             
  | 3 | WIF | Create disk from cs-scanning snapshot | `cs-scanning-test-disk` | PASS | **PASS** | — |                                                                                                                                   
  | 4 | WIF | Create disk from cs-scanning snapshot | `unauthorized-disk` | DENY | **DENY** | `compute.disks.create` |                                                                                                                  
  | 5 | WIF | Delete disk | `cs-scanning-test-disk` | PASS | **PASS** | — |                                                                                                                                                             
  | 6 | WIF | Delete snapshot | `cs-scanning-test-snapshot` | PASS | **PASS** | — |                                                                                                                                                     
  | 7 | User | Create snapshot | `random-user-snapshot` | PASS | **PASS** | — |                                                                                                                                                         
  | 8 | User | Create disk from snapshot | `random-user-disk` | PASS | **PASS** | — |                                                                                                                                                   
  | 9 | WIF | Create disk from non-cs-scanning snapshot | `cs-scanning-from-random` | DENY | **DENY** | `compute.snapshots.useReadOnly` |                                                                                               
  | 10 | WIF | Delete snapshot | `random-user-snapshot` | DENY | **DENY** | `compute.snapshots.delete` |                                                                                                                                
  | 11 | WIF | Delete disk | `random-user-disk` | DENY | **DENY** | `compute.disks.delete` |                                                                                                                                            
                                                                                                                                                                                                                                        
  </details>                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  Conditions enforce that the WIF principal can snapshot any customer disk, but all resulting resources must follow the `cs-scanning-*` naming convention. It cannot read, delete, or create resources outside that convention.
                                                                                                                                                                                                   
  ## Test Plan                                                                                                                                                                                                 
                                                                                                                                                                                                               
  Ran 24 end-to-end scenarios on `dodo-red` covering all registration mode × feature flag combinations with `terraform apply` + `gcloud` role verification + `terraform destroy`.
                                                                                                                                                                                                               
  | # | Mode | Features | Status | Notes |           
  |---|------|----------|--------|-------|                                                                                                                                                                     
  | 1 | Single project | Neither | PASS | Module not created (39 base resources) |                                                                                                                             
  | 2 | Single project | Vuln only | PASS | VulnScannerDisk + VulnScanningOrch roles created, no GCS roles |                                                                                                   
  | 3 | Single project | DSPM only | PASS | GCS roles created, no vuln roles |                                                                                                                                 
  | 4 | Single project | Both | PASS | All 3 roles created (GCS + VulnDisk + VulnOrch) |                                                                                                                       
  | 5 | Single project | DSPM → add vuln | PASS | 6 added, 0 destroyed (incremental) |                                                                                                                         
  | 6 | Multi-project (no cross) | Neither | PASS | Module not created, 110 base resources |                                                                                                                   
  | 7 | Multi-project (no cross) | Vuln only | PASS | Per-project vuln roles, no GCS |                                                                                                                         
  | 8 | Multi-project (no cross) | DSPM only | PASS | Per-project GCS roles, no vuln |                                                                                                                         
  | 9 | Multi-project (no cross) | Both | PASS | All 3 roles per project |                                                                                                                                     
  | 10 | Multi-project (no cross) | DSPM → add vuln | PASS | 18 added, 0 destroyed (incremental) |                                                                                                             
  | 11 | Cross (host_project_id) | Neither | PASS | No agentless roles, 110 base resources |                                                                                                                   
  | 12 | Cross | Vuln only | PASS | Host: ComputeMgr+VulnDisk+VulnOrch, Targets: VulnOrch |                                                                                                                    
  | 13 | Cross | DSPM only | PASS | Host: ComputeMgr+GCS, Targets: GCS only |                                                                                                                                  
  | 14 | Cross | Both | PASS | Host: all 4 roles, Targets: GCS+VulnOrch |                                                                                                                                      
  | 15 | Cross | DSPM → add vuln | PASS | 12 added, 0 destroyed (incremental cross) |                                                                                                                          
  | 16 | Folder | Neither | PASS | No agentless roles, 81 base resources |                                                                                                                                     
  | 17 | Folder | DSPM → add vuln | PASS | 7 added, 0 destroyed (incremental folder) |                                                                                                                         
  | 18 | Folder | Both | PASS | Host: ComputeMgr+VulnDisk, Org: GCS+VulnOrch |                                                                                                                                 
  | 19 | Single project | Vuln → add DSPM | PASS | 3 added, 0 destroyed (GCS added) |                                                                                                                          
  | 20 | Single project | Vuln → neither | PASS | 38 agentless resources destroyed cleanly |                                                                                                                   
  | 21 | Cross | Vuln → add DSPM | PASS | 9 added, 0 destroyed (GCS on host+targets) |                                                                                                                         
  | 22 | Cross | Vuln → neither | PASS | 62 agentless resources destroyed cleanly |                                                                                                                            
  | 23 | Folder | Vuln → add DSPM | PASS | 4 added, 0 destroyed (org GCS + folder bindings) |                                                                                                                  
  | 24 | Folder | Vuln → neither | PASS | 47 agentless resources destroyed cleanly |                                                                                                                           
                                                                                                                                                                                                               
  All incremental transitions add resources without destroying existing ones. All disable transitions cleanly remove the agentless module.