### PR TITLE
CSPG-97337-agentless-scanning-scanner-sa-add-role

### DIFF
--- a/modules/agentless-scanning/README.md
+++ b/modules/agentless-scanning/README.md
@@ -101,6 +101,7 @@ module "agentless_scanning" {
 | [google_secret_manager_secret_iam_member.scanner_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.falcon_credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_service_account.scanner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_member.scanner_sa_self_use](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_service_account_iam_member.wif_can_use_scanner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [random_id.folder_org_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.folder_vulnerability_role_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |

--- a/modules/agentless-scanning/iam.tf
+++ b/modules/agentless-scanning/iam.tf
@@ -165,6 +165,15 @@ resource "google_service_account_iam_member" "wif_can_use_scanner_sa" {
   member             = local.agentless_wif_principal
 }
 
+# Scanner SA can use itself (required to modify the instance it runs on)
+resource "google_service_account_iam_member" "scanner_sa_self_use" {
+  for_each = toset(local.host_project_ids)
+
+  service_account_id = google_service_account.scanner_sa[each.value].id
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.scanner_sa[each.value].email}"
+}
+
 # =============================================================================
 # WIF Principal - Vulnerability Scanning Target Role (project registrations)
 # =============================================================================


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                            
                                                     
  - Scanner SA gets `iam.serviceAccountUser` on itself (required to attach/detach disks on the instance it runs on)    